### PR TITLE
"headless" support for VMs (non-desktop linux instances) Issue #15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Binary releases
 /dist/
 /gphotos-uploader-cli
-
+/cmd/gphotos-uploader-cli/gphotos-uploader-cli
+/main
 # Tests files
 /coverage.txt

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ import (
 type APIAppCredentials struct {
 	ClientID     string
 	ClientSecret string
+	RedirectURL  string
 }
 
 type FolderUploadJob struct {
@@ -96,7 +97,13 @@ func OAuthConfig(uploaderConfigAPICredentials *APIAppCredentials) *oauth2.Config
 	if uploaderConfigAPICredentials == nil {
 		log.Fatalf("APIAppCredentials can't be nil")
 	}
-	return gphotos.NewOAuthConfig(gphotos.APIAppCredentials(*uploaderConfigAPICredentials))
+	oauthConfig := gphotos.NewOAuthConfig(gphotos.APIAppCredentials{uploaderConfigAPICredentials.ClientID, uploaderConfigAPICredentials.ClientSecret})
+	if uploaderConfigAPICredentials.RedirectURL == "" {
+		oauthConfig.RedirectURL = "http://127.0.0.1:14565/oauth/callback"
+	} else {
+		oauthConfig.RedirectURL = uploaderConfigAPICredentials.RedirectURL
+	}
+	return oauthConfig
 }
 
 // GetUploadsDBPath returns the absolute path of uploads DB file

--- a/datastore/completeduploads/completeduploads.go
+++ b/datastore/completeduploads/completeduploads.go
@@ -17,6 +17,10 @@ type CompletedUploadsService struct {
 	db *leveldb.DB
 }
 
+func (c *CompletedUploadsService) DB() *leveldb.DB {
+	return c.db
+}
+
 func NewService(db *leveldb.DB) *CompletedUploadsService {
 	return &CompletedUploadsService{db}
 }

--- a/datastore/tokenstore/tokenstore_leveldb.go
+++ b/datastore/tokenstore/tokenstore_leveldb.go
@@ -1,0 +1,58 @@
+package tokenstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/syndtr/goleveldb/leveldb"
+	"golang.org/x/oauth2"
+)
+
+const keyPrefix = "credential"
+
+// TokenLevelDB Stores credentials in main leveldb under key "credential_USERNAME
+type TokenLevelDB struct {
+	DB *leveldb.DB
+}
+
+func keyFor(user string) []byte {
+	return []byte(fmt.Sprintf("%s_%s", keyPrefix, user))
+}
+
+// RetrieveToken return users token
+func (t TokenLevelDB) RetrieveToken(user string) (*oauth2.Token, error) {
+	tokenJSONString, err := t.DB.Get(keyFor(user), nil)
+	if err == leveldb.ErrNotFound {
+		log.Printf("Error finding credential")
+		return nil, ErrNotFound
+	}
+
+	var token oauth2.Token
+	err = json.Unmarshal([]byte(tokenJSONString), &token)
+	if err != nil {
+		return nil, fmt.Errorf("failed unmarshaling token: %v", err)
+	}
+	// validate token
+	if !token.Valid() {
+		return nil, ErrInvalidToken
+	}
+	return &token, nil
+}
+
+// StoreToken set users token
+func (t TokenLevelDB) StoreToken(user string, token *oauth2.Token) error {
+	tokenJSONBytes, err := json.Marshal(token)
+	if err != nil {
+		log.Printf("error marshalling token")
+		return err
+	}
+
+	err = t.DB.Put(keyFor(user), tokenJSONBytes, nil)
+
+	if err != nil {
+		return err
+	}
+	log.Printf("stored token for user: %s", user)
+	return nil
+}


### PR DESCRIPTION
**DEPS** : check out https://github.com/tonymet/oauth2-noserver/commits/feature/headless first

Addresses Issue #15 -- gphotos-uploader-cli will now run on a standard linux vm without gnome installed (tested on ubuntu & chromium)

* tests for dbus, and uses main leveldb (key = `credential_USERNAME` ) for credentials if dbus is not running .  Otherwise uses `zolando/go-keyring` as before.
* allows `redirectURL` to be set in config as `APIAppCredentials.RedirectURL` (needs `tonymet/feature/headless` branch of `oauth2-noserver`)


### Example config
```
{
  APIAppCredentials: {
    ClientID:     "XXXX"
    ClientSecret: "YYYYYY",
    RedirectURL:  "http://myserver.tonym.us/oauth/callback"
....
}
```