### PR TITLE
Resumable uploads

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,9 +57,9 @@ func startUploader(cmd *cobra.Command, args []string) {
 	}
 
 	// load completedUploads DB
-	db, err := leveldb.OpenFile(cfg.CompletedUploadsTrackingDBDir(), nil)
+	db, err := leveldb.OpenFile(cfg.CompletedUploadsDBDir(), nil)
 	if err != nil {
-		log.Fatalf("Error opening completed uploads db: path=%s, err=%v", cfg.CompletedUploadsTrackingDBDir(), err)
+		log.Fatalf("Error opening completed uploads db: path=%s, err=%v", cfg.CompletedUploadsDBDir(), err)
 	}
 	defer func() {
 		if err := db.Close(); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,12 +76,16 @@ func startUploader(cmd *cobra.Command, args []string) {
 	tkm := tokenstore.NewService(kr)
 
 	// load upload URLs DB
-	uploadURLsdb, err := leveldb.OpenFile(cfg.ResumableUploadsDBDir(), nil)
+	db, err = leveldb.OpenFile(cfg.ResumableUploadsDBDir(), nil)
 	if err != nil {
 		log.Fatalf("Error opening upload URLs db: path=%s, err=%v", cfg.ResumableUploadsDBDir(), err)
 	}
-	defer uploadURLsdb.Close()
-	uploadURLsService := uploadurls.NewService(uploadURLsdb)
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+	uploadURLsService := uploadurls.NewService(db)
 
 	// start file upload worker
 	uploadChan, doneUploading := upload.StartFileUploadWorker(fileTracker, uploadURLsService)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,9 +76,9 @@ func startUploader(cmd *cobra.Command, args []string) {
 	tkm := tokenstore.NewService(kr)
 
 	// load upload URLs DB
-	uploadURLsdb, err := leveldb.OpenFile(cfg.UploadURLsTrackingDBDir(), nil)
+	uploadURLsdb, err := leveldb.OpenFile(cfg.ResumableUploadsDBDir(), nil)
 	if err != nil {
-		log.Fatalf("Error opening upload URLs db: path=%s, err=%v", cfg.UploadURLsTrackingDBDir(), err)
+		log.Fatalf("Error opening upload URLs db: path=%s, err=%v", cfg.ResumableUploadsDBDir(), err)
 	}
 	defer uploadURLsdb.Close()
 	uploadURLsService := uploadurls.NewService(uploadURLsdb)

--- a/config/config.go
+++ b/config/config.go
@@ -42,8 +42,8 @@ func NewConfig(dir string) *Config {
 	return cfg
 }
 
-// CompletedUploadsTrackingDBDir returns the path of the folder where completed uploads are tracked.
-func (c *Config) CompletedUploadsTrackingDBDir() string {
+// CompletedUploadsDBDir returns the path of the folder where completed uploads are tracked.
+func (c *Config) CompletedUploadsDBDir() string {
 	return path.Join(c.ConfigPath, "uploads.db")
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -42,9 +42,14 @@ func NewConfig(dir string) *Config {
 	return cfg
 }
 
-// TrackingDBDir returns the path of the folder where completed uploads are tracked.
-func (c *Config) TrackingDBDir() string {
+// CompletedUploadsTrackingDBDir returns the path of the folder where completed uploads are tracked.
+func (c *Config) CompletedUploadsTrackingDBDir() string {
 	return path.Join(c.ConfigPath, "uploads.db")
+}
+
+// UploadURLsTrackingDBDir returns the path of the folder where upload URLs are tracked.
+func (c *Config) UploadURLsTrackingDBDir() string {
+	return path.Join(c.ConfigPath, "uploadsurls.db")
 }
 
 // ConfigFile return the path of the configuration file.

--- a/config/config.go
+++ b/config/config.go
@@ -49,7 +49,7 @@ func (c *Config) CompletedUploadsDBDir() string {
 
 // ResumableUploadsDBDir returns the path of the folder where upload URLs are tracked.
 func (c *Config) ResumableUploadsDBDir() string {
-	return path.Join(c.ConfigPath, "uploadsurls.db")
+	return path.Join(c.ConfigPath, "resumable_uploads.db")
 }
 
 // ConfigFile return the path of the configuration file.

--- a/config/config.go
+++ b/config/config.go
@@ -47,8 +47,8 @@ func (c *Config) CompletedUploadsDBDir() string {
 	return path.Join(c.ConfigPath, "uploads.db")
 }
 
-// UploadURLsTrackingDBDir returns the path of the folder where upload URLs are tracked.
-func (c *Config) UploadURLsTrackingDBDir() string {
+// ResumableUploadsDBDir returns the path of the folder where upload URLs are tracked.
+func (c *Config) ResumableUploadsDBDir() string {
 	return path.Join(c.ConfigPath, "uploadsurls.db")
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -89,7 +89,7 @@ func TestLoadConfigWithNonExistentFile(t *testing.T) {
 	}
 }
 
-func TestConfig_TrackingDBDir(t *testing.T) {
+func TestConfig_CompletedUploadsDBDir(t *testing.T) {
 	dir := filepath.Join(os.TempDir(), fmt.Sprintf("gphotos-config.%d", time.Now().UnixNano()))
 	c := config.NewConfig(dir)
 
@@ -97,7 +97,20 @@ func TestConfig_TrackingDBDir(t *testing.T) {
 	got := c.CompletedUploadsDBDir()
 
 	if got != expected {
-		t.Errorf("Testing get tracking DB dir: expected: %s, got %s", expected, got)
+		t.Errorf("Testing get completed uploads DB dir: expected: %s, got %s", expected, got)
+	}
+
+}
+
+func TestConfig_ResumableUploadsDBDir(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), fmt.Sprintf("gphotos-config.%d", time.Now().UnixNano()))
+	c := config.NewConfig(dir)
+
+	expected := path.Join(dir, "resumable_uploads.db")
+	got := c.ResumableUploadsDBDir()
+
+	if got != expected {
+		t.Errorf("Testing get resumable uploads DB dir: expected: %s, got %s", expected, got)
 	}
 
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -94,7 +94,7 @@ func TestConfig_TrackingDBDir(t *testing.T) {
 	c := config.NewConfig(dir)
 
 	expected := path.Join(dir, "uploads.db")
-	got := c.CompletedUploadsTrackingDBDir()
+	got := c.CompletedUploadsDBDir()
 
 	if got != expected {
 		t.Errorf("Testing get tracking DB dir: expected: %s, got %s", expected, got)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -94,7 +94,7 @@ func TestConfig_TrackingDBDir(t *testing.T) {
 	c := config.NewConfig(dir)
 
 	expected := path.Join(dir, "uploads.db")
-	got := c.TrackingDBDir()
+	got := c.CompletedUploadsTrackingDBDir()
 
 	if got != expected {
 		t.Errorf("Testing get tracking DB dir: expected: %s, got %s", expected, got)

--- a/datastore/uploadurls/uploadurls.go
+++ b/datastore/uploadurls/uploadurls.go
@@ -1,0 +1,101 @@
+package uploadurls
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/pierrec/xxHash/xxHash32"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+type Service struct {
+	db *leveldb.DB
+}
+
+func NewService(db *leveldb.DB) *Service {
+	return &Service{db}
+}
+
+// TODO: refactor with completeduploads
+func hashFile(filePath string) (uint32, error) {
+	inputFile, err := os.Open(filePath)
+	if err != nil {
+		return 0, err
+	}
+	defer inputFile.Close()
+
+	hasher := xxHash32.New(0xCAFE) // hash.Hash32
+	defer hasher.Reset()
+
+	_, err = io.Copy(hasher, inputFile)
+	if err != nil {
+		return 0, err
+	}
+
+	return hasher.Sum32(), nil
+}
+
+// GetUploadURL gets upload URL from database if available for resumable upload
+func (s *Service) GetUploadURL(filePath string) (string, error) {
+	// look for upload URL in database
+	val, err := s.db.Get([]byte(filePath), nil)
+	if err == leveldb.ErrNotFound {
+		return "", nil
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	// value found, try to split hash and upload URL
+	strval := string(val[:])
+	parts := strings.Split(strval, "|")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("failed parsing upload URL data from database: %s", strval)
+
+	}
+	cacheHash := parts[0]
+	uploadURL := parts[1]
+
+	fileHash, err := hashFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	if cacheHash != fmt.Sprint(fileHash) {
+		err = s.RemoveUploadURL(filePath)
+		if err != nil {
+			return "", fmt.Errorf("failed to remove upload URL from database: %s", err)
+		}
+
+		return "", nil
+	}
+
+	return uploadURL, err
+}
+
+// PutUploadURL puts a file's upload URL in database for resumable upload
+func (s *Service) PutUploadURL(filePath, uploadURL string) error {
+	fileHash, err := hashFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	val := fmt.Sprint(fileHash) + "|" + uploadURL
+	err = s.db.Put([]byte(filePath), []byte(val), nil)
+	if err != nil {
+		return err
+	}
+	log.Printf("Stored upload URL for file %s (%s)", filePath, uploadURL)
+
+	return nil
+}
+
+// RemoveUploadURL removes a file's upload URL from the database
+func (s *Service) RemoveUploadURL(filePath string) error {
+	log.Printf("Removing file's upload URL from DB: %s", filePath)
+	return s.db.Delete([]byte(filePath), nil)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/99designs/keyring v0.0.0-20190704105226-2c916c935b9f
 	github.com/client9/xson v0.0.0-20180321172152-0e50cdfc08c0
-	github.com/gphotosuploader/google-photos-api-client-go v1.0.1
+	github.com/gphotosuploader/google-photos-api-client-go v1.0.3
 	github.com/gphotosuploader/googlemirror v0.3.2
 	github.com/int128/oauth2cli v1.4.1
 	github.com/juju/errors v0.0.0-20190207033735-e65537c515d7

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/gphotosuploader/google-photos-api-client-go v1.0.1 h1:GABwfafKIshYuIyw1kKZQDvluq0xBeTjdUCtmb1RWq0=
 github.com/gphotosuploader/google-photos-api-client-go v1.0.1/go.mod h1:BpVu00UDZ5P0GJ4rFS5X9OiMF/av7Jb2M0Xd7ex/izI=
+github.com/gphotosuploader/google-photos-api-client-go v1.0.3 h1:fw6sta6RAc7To42TJeuQ2/EZDquWwJ3pTOo5nFfxnf8=
+github.com/gphotosuploader/google-photos-api-client-go v1.0.3/go.mod h1:7D8+4oKnv2TcdWSURiNCZ4eDQkVHkFJgfAUQhucVjXY=
 github.com/gphotosuploader/googlemirror v0.0.0-20190708130251-f249ce03cd95 h1:Cv0811GX9b3ql90ANuJdvHCX2s2THyalfDOfDl2vOZQ=
 github.com/gphotosuploader/googlemirror v0.0.0-20190708130251-f249ce03cd95/go.mod h1:725+/afSOVU01M2Lfi3NIw8L3Oupjit6u/s1MLjK160=
 github.com/gphotosuploader/googlemirror v0.3.2 h1:xaYVJYEDj2rYMYGi5sTGMy6gkD5PVKfz4c3ZW8gQs+M=

--- a/upload/fileUpload.go
+++ b/upload/fileUpload.go
@@ -1,12 +1,14 @@
 package upload
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/juju/errors"
 
 	gphotos "github.com/gphotosuploader/google-photos-api-client-go/lib-gphotos"
 	"github.com/gphotosuploader/gphotos-uploader-cli/datastore/completeduploads"
+	"github.com/gphotosuploader/gphotos-uploader-cli/datastore/uploadurls"
 )
 
 // number of concurrent workers uploading items
@@ -27,13 +29,13 @@ type Item struct {
 //  eg: https://gobyexample.com/worker-pools
 //  eg: https://gobyexample.com/waitgroups
 //  eg: https://github.schibsted.io/spt-infrastructure/yams-delivery-images/blob/master/images/image_gif.go
-func concurrentUpload(fileUploadsChan <-chan *Item, doneUploading chan<- bool, completedUploads *completeduploads.Service) {
+func concurrentUpload(fileUploadsChan <-chan *Item, doneUploading chan<- bool, completedUploads *completeduploads.Service, uploadURLsService *uploadurls.Service) {
 	semaphore := make(chan bool, maxNumberOfWorkers)
 	for fileUpload := range fileUploadsChan {
 		semaphore <- true
 		go func(fileUpload *Item) {
 			defer func() { <-semaphore }()
-			err := fileUpload.upload(completedUploads)
+			err := fileUpload.upload(completedUploads, uploadURLsService)
 			if err != nil {
 				log.Fatal(errors.Annotate(err, "failed uploading image"))
 			}
@@ -49,10 +51,10 @@ func concurrentUpload(fileUploadsChan <-chan *Item, doneUploading chan<- bool, c
 // StartFileUploadWorker set up channels and start concurrentUpload
 // fileUploadsChan will receive Item structs and upload them
 // will signal doneUploading when fileUploadsChan is done
-func StartFileUploadWorker(trackingService *completeduploads.Service) (fileUploadsChan chan *Item, doneUploading chan bool) {
+func StartFileUploadWorker(trackingService *completeduploads.Service, uploadURLsService *uploadurls.Service) (fileUploadsChan chan *Item, doneUploading chan bool) {
 	doneUploading = make(chan bool)
 	fileUploadsChan = make(chan *Item)
-	go concurrentUpload(fileUploadsChan, doneUploading, trackingService)
+	go concurrentUpload(fileUploadsChan, doneUploading, trackingService, uploadURLsService)
 	return fileUploadsChan, doneUploading
 }
 
@@ -71,14 +73,37 @@ func getGooglePhotosAlbumID(name string, c *gphotos.Client) string {
 	return album.Id
 }
 
-func (f *Item) upload(completedUploads *completeduploads.Service) error {
+func (f *Item) upload(completedUploads *completeduploads.Service, uploadURLsService *uploadurls.Service) error {
 	albumID := getGooglePhotosAlbumID(f.album, f.client)
 	log.Printf("Uploading object: file=%s", f.path)
 
-	// upload the file content to Google Photos
-	_, err := f.client.UploadFile(f.path, albumID)
+	// check upload URL db for previous uploads
+	log.Println("Looking up upload URLs database for ", f.path)
+	curUploadURL, err := uploadURLsService.GetUploadURL(f.path)
 	if err != nil {
-		return errors.Annotate(err, "failed uploading image")
+		// Not found, not an error, just an empty upload URL
+		log.Println(err)
+	}
+
+	// upload the file content to Google Photos
+	ptrUploadURL := &curUploadURL
+	_, err = f.client.UploadFileResumable(f.path, ptrUploadURL, albumID)
+	if err != nil {
+		err = errors.Annotate(err, "failed uploading image")
+	}
+
+	if err != nil && *ptrUploadURL != "" {
+		log.Printf("Error uploading file '%s', storing upload URL '%s'\n", f.path, *ptrUploadURL)
+		if uploadURLsService.PutUploadURL(f.path, *ptrUploadURL) != nil {
+			return fmt.Errorf("failed to store upload URL in database: %s", err)
+		}
+
+		return err
+	}
+
+	err = uploadURLsService.RemoveUploadURL(f.path)
+	if err != nil {
+		return fmt.Errorf("failed to remove upload URL from database: %s", err)
 	}
 
 	// mark file as uploaded in the DB

--- a/upload/fileUpload.go
+++ b/upload/fileUpload.go
@@ -94,7 +94,7 @@ func (f *Item) upload(completedUploads *completeduploads.Service, uploadURLsServ
 	}
 
 	if err != nil && *ptrUploadURL != "" {
-		log.Printf("Error uploading file '%s', storing upload URL '%s'\n", f.path, *ptrUploadURL)
+		log.Printf("Error uploading file '%s', storing upload URL '%s'", f.path, *ptrUploadURL)
 		if uploadURLsService.PutUploadURL(f.path, *ptrUploadURL) != nil {
 			return fmt.Errorf("failed to store upload URL in database: %s", err)
 		}

--- a/upload/fileUpload.go
+++ b/upload/fileUpload.go
@@ -82,6 +82,7 @@ func (f *Item) upload(completedUploads *completeduploads.Service, uploadURLsServ
 	curUploadURL, err := uploadURLsService.GetUploadURL(f.path)
 	if err != nil {
 		// Not found, not an error, just an empty upload URL
+		curUploadURL = ""
 		log.Println(err)
 	}
 

--- a/upload/folderUploadJob.go
+++ b/upload/folderUploadJob.go
@@ -10,13 +10,15 @@ import (
 
 	gphotos "github.com/gphotosuploader/google-photos-api-client-go/lib-gphotos"
 	"github.com/gphotosuploader/gphotos-uploader-cli/datastore/completeduploads"
+	"github.com/gphotosuploader/gphotos-uploader-cli/datastore/uploadurls"
 	"github.com/gphotosuploader/gphotos-uploader-cli/utils/filesystem"
 )
 
 // Job represents a job to upload all photos from the specified folder
 type Job struct {
-	client          *gphotos.Client
-	trackingService *completeduploads.Service
+	client            *gphotos.Client
+	trackingService   *completeduploads.Service
+	uploadURLsService *uploadurls.Service
 
 	sourceFolder string
 	options      *JobOptions
@@ -43,10 +45,11 @@ func NewJobOptions(createAlbum bool, deleteAfterUpload bool, uploadVideos bool, 
 }
 
 // NewFolderUploadJob creates a job based on the submitted data
-func NewFolderUploadJob(client *gphotos.Client, trackingService *completeduploads.Service, fp string, opt *JobOptions) *Job {
+func NewFolderUploadJob(client *gphotos.Client, trackingService *completeduploads.Service, uploadURLsService *uploadurls.Service, fp string, opt *JobOptions) *Job {
 	return &Job{
-		trackingService: trackingService,
-		client:          client,
+		trackingService:   trackingService,
+		uploadURLsService: uploadURLsService,
+		client:            client,
 
 		sourceFolder: fp,
 		options:      opt,
@@ -92,7 +95,7 @@ func (job *Job) ScanFolder(uploadChan chan<- *Item) error {
 			return nil
 		}
 
-		// check upload db for previous uploads
+		// check completed uploads db for previous uploads
 		isAlreadyUploaded, err := job.trackingService.IsAlreadyUploaded(fp)
 		if err != nil {
 			log.Println(err)


### PR DESCRIPTION
That PR implements resumable uploads.

For now, I've implemented the upload url storage in a separate database to avoid polluting the main database while testing. That decision can be revised if desired.

Note: this depends on https://github.com/gphotosuploader/google-photos-api-client-go/pull/5