### PR TITLE
Fix issue #25 - Enable object deletion after successful upload

### DIFF
--- a/datastore/completeduploads/completeduploads.go
+++ b/datastore/completeduploads/completeduploads.go
@@ -2,7 +2,6 @@ package completeduploads
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/gphotosuploader/gphotos-uploader-cli/utils/filesystem"
 )
@@ -72,16 +71,10 @@ func (s *Service) CacheAsAlreadyUploaded(filePath string) error {
 	if err != nil {
 		return err
 	}
-	err = s.repo.Put(item)
-	if err != nil {
-		return err
-	}
-	log.Printf("Marked as uploaded: %s", filePath)
-	return nil
+	return s.repo.Put(item)
 }
 
 // RemoveAsAlreadyUploaded removes a file previously marked as uploaded
 func (s *Service) RemoveAsAlreadyUploaded(filePath string) error {
-	log.Printf("Removing file from upload repository: %s", filePath)
 	return s.repo.Delete(filePath)
 }

--- a/upload/deletion.go
+++ b/upload/deletion.go
@@ -5,79 +5,70 @@ import (
 	"os"
 
 	"github.com/juju/errors"
-
-	"github.com/gphotosuploader/gphotos-uploader-cli/filetypes"
 )
 
 var (
-	deletionsChan = make(chan DeletionJob)
+	deletionQueue = make(chan DeletionJob, 25)
 )
 
-// DeletionJob represents an object to be deleted from local repository
+// DeletionJob represents an object to be deleted from local repository.
 type DeletionJob struct {
-	uploadedFileURL string
-	localFilePath   string
-	typedMedia      filetypes.TypedMedia
+	ObjectURL  string
+	ObjectPath string
 }
 
-// TODO: create a new type DeletionQueue. The rest are methods of it
-
-// QueueDeletionJob adds an object to be deleted to an asynchronous queue.
-// It checks that all the parameters are set or return error otherwise.
-func QueueDeletionJob(deletionJob DeletionJob) error {
-	// check params
-	{
-		if deletionJob.uploadedFileURL == "" {
-			return errors.NewNotValid(nil, "missing uploadedFileURL for deletionJob")
-		}
-		if deletionJob.localFilePath == "" {
-			return errors.NewNotValid(nil, "missing localFilePath for deletionJob")
-		}
-		if deletionJob.typedMedia == nil {
-			return errors.NewNotValid(nil, "missing typedMedia for deletionJob")
-		}
-	}
-
-	deletionsChan <- deletionJob
+// Enqueue adds an object to be deleted to an asynchronous queue.
+func (j *DeletionJob) Enqueue() error {
+	deletionQueue <- *j
 	return nil
 }
 
-// CloseDeletionChan close the channel used for removing objects
-func CloseDeletionsChan() { close(deletionsChan) }
+func (j *DeletionJob) deleteIfCorrectlyUploaded() error {
+	if j.ObjectURL == "" {
+		return errors.NewNotValid(nil, "file was not correctly uploaded, skipping deletion")
+	}
 
-// StartDeletionsWorker set up channels and start concurrent deletions
-// deletionsChan will receive DeletionJob structs and delete the object
-// from local repository, it will signal doneDeleting when removal is done
-func StartDeletionsWorker() (doneDeleting chan struct{}) {
-	doneDeleting = make(chan struct{})
-	go func() {
-		for deletionJob := range deletionsChan {
-			_ = deletionJob.deleteIfCorrectlyUploaded()
-		}
-		doneDeleting <- struct{}{}
-	}()
-	return doneDeleting
+	err := os.Remove(j.ObjectPath)
+	return err
 }
 
-func (deletionJob *DeletionJob) deleteIfCorrectlyUploaded() error {
-	isCorrectlyUploaded, err := deletionJob.typedMedia.IsCorrectlyUploaded(deletionJob.uploadedFileURL, deletionJob.localFilePath)
-	if err != nil {
-		log.Printf("%s. Won't delete\n", err)
-		return err
-	}
+// DeletionQueue is an async queue to process deletion requests.
+// Requests will receive DeletionJob structs to be deleted from local repository.
+// DoneChannel will be signalled when removal is done.
+type DeletionQueue struct {
+	Requests    chan DeletionJob
+	DoneChannel chan bool
+}
 
-	if isCorrectlyUploaded {
-		log.Printf("uploaded file %s was checked for integrity. Will now delete.\n", deletionJob.localFilePath)
-		if err = os.Remove(deletionJob.localFilePath); err != nil {
-			log.Println("failed deleting file")
+// NewDeletionQueue returns a new DeletionQueue object.
+func NewDeletionQueue() *DeletionQueue {
+	return &DeletionQueue{
+		Requests:    deletionQueue,
+		DoneChannel: make(chan bool),
+	}
+}
+
+// StartWorkers start concurrent deletion workers.
+func (q *DeletionQueue) StartWorkers() {
+	go func() {
+		for job := range q.Requests {
+			log.Printf("Deletion worker: Processing deletion request for: file=%s", job.ObjectPath)
+			err := job.deleteIfCorrectlyUploaded()
+			if err != nil {
+				log.Printf("File has not been deleted: file=%s, err=%v", job.ObjectPath, err)
+			}
 		}
+		q.DoneChannel <- true
+	}()
+}
 
-		//if err = RemoveAsAlreadyUploaded(deletionJob.localFilePath); err != nil {
-		//	log.Printf("Failed to remove from DB: %s", err)
-		//}
-		return err
-	}
+// Close closes the queue to avoid new jobs are added.
+func (q *DeletionQueue) Close() {
+	close(q.Requests)
+}
 
-	log.Println("not the same image. Won't delete")
-	return err
+// WaitForWorkers waits for deletions to be completed.
+// It waits until quit channel is read.
+func (q *DeletionQueue) WaitForWorkers() {
+	<-q.DoneChannel
 }

--- a/upload/deletion.go
+++ b/upload/deletion.go
@@ -13,7 +13,6 @@ var (
 
 // DeletionJob represents an object to be deleted from local repository.
 type DeletionJob struct {
-	ObjectURL  string
 	ObjectPath string
 }
 
@@ -24,8 +23,8 @@ func (j *DeletionJob) Enqueue() error {
 }
 
 func (j *DeletionJob) deleteIfCorrectlyUploaded() error {
-	if j.ObjectURL == "" {
-		return errors.NewNotValid(nil, "file was not correctly uploaded, skipping deletion")
+	if j.ObjectPath == "" {
+		return errors.NewNotValid(nil, "object path is empty")
 	}
 
 	err := os.Remove(j.ObjectPath)
@@ -52,10 +51,10 @@ func NewDeletionQueue() *DeletionQueue {
 func (q *DeletionQueue) StartWorkers() {
 	go func() {
 		for job := range q.Requests {
-			log.Printf("Deletion worker: Processing deletion request for: file=%s", job.ObjectPath)
+			log.Printf("Processing deletion request: file=%s", job.ObjectPath)
 			err := job.deleteIfCorrectlyUploaded()
 			if err != nil {
-				log.Printf("File has not been deleted: file=%s, err=%v", job.ObjectPath, err)
+				log.Printf("Deletion request failed: file=%s, err=%v\n", job.ObjectPath, err)
 			}
 		}
 		q.DoneChannel <- true

--- a/upload/folderUploadJob.go
+++ b/upload/folderUploadJob.go
@@ -107,18 +107,12 @@ func (job *job) ScanFolder(uploadChan chan<- *Item) error {
 			album = filepath.Base(filepath.Dir(fp))
 		}
 
-		// TODO: Fix issue #25 - Removal of GIF & Videos is broken: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/25
-		// v0.4.0: Disable all files removal until we fix the issue properly
-		if job.deleteAfterUpload {
-			log.Printf("[WARNING] Removal of local files has been disabled. (See issue #25 https://github.com/gphotosuploader/gphotos-uploader-cli/issues/25")
-		}
-
 		// set file upload options depending on folder upload options
 		var uploadItem = &Item{
 			client:          job.client,
 			path:            fp,
 			album:           album,
-			deleteOnSuccess: false, // TODO: Fix issue #25 - Removal of GIF & Videos is broken: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/25
+			deleteOnSuccess: job.deleteAfterUpload,
 		}
 
 		// finally, add the file upload to the queue


### PR DESCRIPTION
After an object has been correctly uploaded, a deletion request is enqueued in a queue. A pool (1) of workers are leading with that queue, removing files from local repository.

`deleteIfCorrectlyUploaded()` ensures that object was uploaded properly before remove it. It's only checking that the uploaded object has an URL. More complex checks could be added in the future, if they are needed.

Closes #25 