### PR TITLE
Re-enable 'deleteAfterUpload' option

### DIFF
--- a/.docs/configuration.md
+++ b/.docs/configuration.md
@@ -77,10 +77,9 @@ Must be an absolute path. Can expand the home folder tilde shorthand.
 If makeAlbums.enabled set to true, use the last folder path component as album name.
 
 ### `deleteAfterUpload`
-> **ATTENTION:** For v0.4.0+ this option has been disabled due to several problems detecting similarities between uploaded and local files. **So no file will be removed from local storage by this CLI** See [issue #45](https://github.com/gphotosuploader/gphotos-uploader-cli/issues/25) for more details.
-  
-~~If set to true, media will be deleted from local disk after upload. 
-To avoid data corruption, the uploader will double check that a the picture exists in your library and is visually similar to the one on the local disk before deleting any file.~~
+If set to true, media will be deleted from local disk after upload. 
+
+> **NOTE:** This option was not working properly prior v0.6.0.
 
 ### `uploadVideos`
 > **DEPRECATION NOTICE:** This option will be deprecated in the future in favor of `_ALL_VIDEO_FILES_` tagged pattern used in `includePatterns` or `excludePatterns`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.6.0
+### Added
+- `deleteAfterUpload` option has been reactivated, it was removed on v0.4.0. If you use this option in [config file](.docs/configuration.md) files will be deleted from local repository after being uploaded to Google Photos.
 ### Changed
 - This repository has transferred to [GPhotos Uploaders organization](https://github.com/gphotosuploader), so all imports has been updated to the new organization's URL.
+### Removed
+- Removed some useless log lines. There are still too much.
 
 ## 0.5.0
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 
 ## 0.6.0
 ### Added
-- `deleteAfterUpload` option has been reactivated, it was removed on v0.4.0. If you use this option in [config file](.docs/configuration.md) files will be deleted from local repository after being uploaded to Google Photos.
+- `deleteAfterUpload` option has been reactivated, it was removed on v0.4.0. If you use this option in [config file](.docs/configuration.md) files will be deleted from local repository after being uploaded to Google Photos. (#25)
 ### Changed
 - This repository has transferred to [GPhotos Uploaders organization](https://github.com/gphotosuploader), so all imports has been updated to the new organization's URL.
 ### Removed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ While the official tool is only supports Mac OS and Windows, this brings an uplo
 - specify folders to upload in config file
 - upload to multiple google accounts
 - include/exclude files & folders using patterns (see [documentation](.docs/configuration.md))
-- ~~optionally delete objects after uploaḍ~~
+- optionally delete objects after uploaḍ
 - security: logs you into google using OAuth (so this app doesn't have to know your password), and stores your temporary access code in your OS's secure storage (keyring/keychain).
 
 # Getting started


### PR DESCRIPTION
Add `deleteAfterUpload` option that was disabled by #25 

Closes #25 