### PR TITLE
fix: issue 127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.8.2
+### Fixed
+- Fix panic when a very big file was uploaded. It was solved in upstream [gphotosuploader/google-photos-api-client-go#17](https://github.com/gphotosuploader/google-photos-api-client-go/issues/17). (#127)
+
 ## 0.8.1
 ### Added
 - Coverage reports in [codecov](https://codecov.io/gh/gphotosuploader/gphotos-uploader-cli/) service.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/99designs/keyring v0.0.0-20190704105226-2c916c935b9f
 	github.com/client9/xson v0.0.0-20180321172152-0e50cdfc08c0
-	github.com/gphotosuploader/google-photos-api-client-go v1.0.4
+	github.com/gphotosuploader/google-photos-api-client-go v1.0.5
 	github.com/gphotosuploader/googlemirror v0.3.2
 	github.com/int128/oauth2cli v1.4.1
 	github.com/juju/errors v0.0.0-20190207033735-e65537c515d7

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/gphotosuploader/google-photos-api-client-go v1.0.3 h1:fw6sta6RAc7To42
 github.com/gphotosuploader/google-photos-api-client-go v1.0.3/go.mod h1:7D8+4oKnv2TcdWSURiNCZ4eDQkVHkFJgfAUQhucVjXY=
 github.com/gphotosuploader/google-photos-api-client-go v1.0.4 h1:9WmIcffu0fRgHKdBCUOpcD+VGuT3kVAOO37qwEJK0F8=
 github.com/gphotosuploader/google-photos-api-client-go v1.0.4/go.mod h1:7D8+4oKnv2TcdWSURiNCZ4eDQkVHkFJgfAUQhucVjXY=
+github.com/gphotosuploader/google-photos-api-client-go v1.0.5 h1:p09OAMonnusKHTHr0WyE2fGGbf9NtWAnDw7XHZdSO/A=
+github.com/gphotosuploader/google-photos-api-client-go v1.0.5/go.mod h1:7D8+4oKnv2TcdWSURiNCZ4eDQkVHkFJgfAUQhucVjXY=
 github.com/gphotosuploader/googlemirror v0.0.0-20190708130251-f249ce03cd95 h1:Cv0811GX9b3ql90ANuJdvHCX2s2THyalfDOfDl2vOZQ=
 github.com/gphotosuploader/googlemirror v0.0.0-20190708130251-f249ce03cd95/go.mod h1:725+/afSOVU01M2Lfi3NIw8L3Oupjit6u/s1MLjK160=
 github.com/gphotosuploader/googlemirror v0.3.2 h1:xaYVJYEDj2rYMYGi5sTGMy6gkD5PVKfz4c3ZW8gQs+M=


### PR DESCRIPTION
Fix panic when a very big file was uploaded. It was solved in upstream [gphotosuploader/google-photos-api-client-go#17](https://github.com/gphotosuploader/google-photos-api-client-go/issues/17)

Closes #127 
