### PR TITLE
Deprecate go-1-11 support in favor of go-1-13.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,57 +1,111 @@
 ---
 kind: pipeline
-name: go-1-11
+name: test
+
+platform:
+  os: linux
+  arch: amd64
 
 steps:
-  - name: test-lint-build
-    image: golang:1.11
-    volumes:
-      - name: deps
-        path: /go
-    commands:
-      - make test COVERAGE_FILE=coverage.txt
-      - make lint
-      - make build
+- name: test-build
+  image: golang:1.13
+  commands:
+  - make test
+  - make build
 
-  - name: coverage
-    image: plugins/codecov
-    settings:
-      required: true
-      token:
-        from_secret: codecov_token
-    files:
-     - coverage.txt
+trigger:
+  branch:
+    exclude:
+    - master
+
+---
+kind: pipeline
+name: test-master-go-1-13
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: test-build
+  image: golang:1.13
+  commands:
+  - make test COVERAGE_FILE=coverage.txt
+  - make build
+  volumes:
+  - name: deps
+    path: /go
+
+- name: lint
+  image: golang:1.13
+  commands:
+  - make lint
+  volumes:
+  - name: deps
+    path: /go
+
+- name: coverage
+  image: plugins/codecov
+  settings:
+    required: true
+    token:
+      from_secret: codecov_token
 
 volumes:
-  - name: deps
-    temp: {}
+- name: deps
+  temp: {}
+
+trigger:
+  branch:
+  - master
+
+---
+kind: pipeline
+name: test-master-go-1-12
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: test-build
+  image: golang:1.12
+  commands:
+  - make test
+  - make build
+
+trigger:
+  branch:
+  - master
 
 ---
 kind: pipeline
 name: release
 
-steps:
-  - name: fetch
-    image: docker:git
-    commands:
-      - git fetch --tags
+platform:
+  os: linux
+  arch: amd64
 
-  - name: release
-    image: golang:1.12
-    environment:
-      GITHUB_TOKEN:
-        from_secret: github_token
-    commands:
-      - make release
+steps:
+- name: fetch
+  image: docker:git
+  commands:
+  - git fetch --tags
+
+- name: release
+  image: golang:1.13
+  commands:
+  - make release
+  environment:
+    GITHUB_TOKEN:
+      from_secret: github_token
 
 trigger:
   event:
   - tag
 
-depends_on:
-  - go-1-11
 ---
 kind: signature
-hmac: 45d7c2ddfde4c90438e05bdeda5933783f125fcf2098ef2eeaaf4714fe74a95b
+hmac: cda23a221a730cd62ef0bf7a9885206085d42654c088eceda87725ddf0162af8
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 - [CONTRIBUTING](CONTRIBUTING.md) guide line has been added.
 ### Changed
 - [README](README.md) has been updated fixing some typos.
+### Deprecated
+- Once Go 1.13 has been published, previous Go 1.11 support is deprecated. This project will maintain compatibility with the last two major versions published.
 
 ## 0.8.7
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+### Added
+- [CONTRIBUTING](CONTRIBUTING.md) guide line has been added.
+### Changed
+- [README](README.md) has been updated fixing some typos.
+
 ## 0.8.7
 ### Changed
 - Update dependencies to newer versions: [gphotosuploader/google-photos-api-client-go](https://github.com/gphotosuploader/google-photos-api-client-go) v1.1.2 and [int128/oauth2cli](https://github.com/int128/oauth2cli) to v1.7.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,12 @@ If you find a bug while working with `gphotos-uploader-cli`, please [open an iss
 You are more than welcome to open issues in this project to [suggest new features](https://github.com/gphotosuploader/gphotos-uploader-cli/issues/new?assignees=&labels=feature+request&template=feature_request.md).
 
 ## Contributing Code
-This project is mainly written in Golang. To contribute code,
-1. Ensure you are running golang version 1.11.4 or greater for go module support
+This project is mainly written in Golang.
+
+> This project will maintain compatibility with the last two Go major versions published. Currently Go 1.12 and Go 1.13.
+
+To contribute code:
+1. Ensure you are running golang version 1.12 or greater
 2. Set the following environment variables:
     ```
     GO111MODULE=on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Please read this guide if you plan to contribute to this project. We welcome any
 If you find a bug while working with `gphotos-uploader-cli`, please [open an issue on GitHub](https://github.com/gphotosuploader/gphotos-uploader-cli/issues/new?assignees=pacoorozco&labels=bug&template=bug_report.md) and let us know what went wrong. We will try to fix it as quickly as we can.
 
 ## Feature Requests
-You are more than welcome to open issues in this project to [suggest new features](https://github.com/gphotosuploader/gphotos-uploader-cli/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=).
+You are more than welcome to open issues in this project to [suggest new features](https://github.com/gphotosuploader/gphotos-uploader-cli/issues/new?assignees=&labels=feature+request&template=feature_request.md).
 
 ## Contributing Code
 This project is mainly written in Golang. To contribute code,

--- a/README.md
+++ b/README.md
@@ -10,16 +10,17 @@
 
 Command line tool to mass upload media folders to your Google Photos account(s).    
 
-While the official tool is only supports Mac OS and Windows, this brings an uploader to Linux too. Lets you upload photos from, in theory, any OS for which you can compile a Go program.     
+While the official tool only supports Mac OS and Windows, this brings an uploader to Linux too. Lets you upload photos from, in theory, any OS for which you can compile a Go program.     
 
-# Features:
+# Features
 
-- specify folders to upload in config file
-- upload to multiple google accounts
-- include/exclude files & folders using patterns (see [documentation](.docs/configuration.md))
-- resumable uploads
-- optionally delete objects after uploaḍ
-- security: logs you into google using OAuth (so this app doesn't have to know your password), and stores your temporary access code in your OS's secure storage (keyring/keychain).
+- **Customizable configuration**: via JSON-like config file.
+- **Multiple Google accounts support**: upload your pictures to multiple accounts.
+- **Filter files with patterns**: include/exclude files & folders using patterns (see [documentation](.docs/configuration.md)).
+- **Resumable uploads**: Uploads can be resumed, saving time and bandwidth. 
+- **File deletion after uploading**: Clean up local files after being uploaded.
+- **Track already uploaded files**: uploads only new files to save bandwidth.
+- **Secure**: logs you into Google using OAuth (so this app doesn't have to know your password), and stores your temporary access code in your OS's secure storage (keyring/keychain).
 
 # Getting started
 
@@ -106,7 +107,19 @@ The first time you run `gphotos-uploader-cli`, after setting your configuration 
 All auth configuration is in place.
 
 # Contributing
-Have improvement ideas or want to help ? Please start by opening an [issue](https://github.com/gphotosuploader/gphotos-uploader-cli/issues). 
+Help us make `gphotos-uploader-cli` the best tool for uploading your local pictures to Google Photos.
+
+## Reporting Issues
+If you find a bug while working with `gphotos-uploader-cli`, please [open an issue on GitHub](https://github.com/gphotosuploader/gphotos-uploader-cli/issues/new?assignees=pacoorozco&labels=bug&template=bug_report.md) and let us know what went wrong. We will try to fix it as quickly as we can.
+
+## Feedback & Feature Requests
+You are more than welcome to open issues in this project to:
+
+- [give feedback](https://github.com/gphotosuploader/gphotos-uploader-cli/issues/new?title=Feedback:)
+- [suggest new features](https://github.com/gphotosuploader/gphotos-uploader-cli/issues/new?labels=feature+request&template=feature_request.md)
+
+## Contributing Code
+This project is mainly written in Golang. If you want to contribute code, see [Contributing guide lines](CONTRIBUTING.md) for more information.
 
 # License
  

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Download the pre-compiled binaries from the [releases page](https://github.com/g
 
 ### Compiling from source
 
-You can compile the source code in your system. **Go 1.11+** is required to compile this application:
+> This project will maintain compatibility with the last two Go major versions published. Currently Go 1.12 and Go 1.13. 
+
+You can compile the source code in your system. **Go 1.12+** is required to compile this application:
 
 ```
 $ git clone https://github.com/gphotosuploader/gphotos-uploader-cli


### PR DESCRIPTION
**What issue type does this pull request address?** 
enhancement

**What is this pull request for?**
Once Go 1.13 has been released, the previous Go 1.11 support is deprecated. This project will maintain compatibility with the last two Go major versions published: currently 1.12 and 1.13.

**Does this pull request has user-facing changes?** 
Requirements to compile are now Go 1.12+