### PR TITLE
Add option to configure Album name

### DIFF
--- a/.docs/configuration.md
+++ b/.docs/configuration.md
@@ -17,7 +17,7 @@ Example configuration file:
       sourceFolder: ~/folder/to/upload
       makeAlbums: {
         enabled: true
-        use: folderNames
+        use: folderName
       }
       deleteAfterUpload: false
       uploadVideos: true
@@ -86,7 +86,22 @@ The folder to upload from.
 Must be an absolute path. Can expand the home folder tilde shorthand.
 
 ### `makeAlbums`
-If makeAlbums.enabled set to true, use the last folder path component as album name.
+If `makeAlbums.enabled` set to true, use the last folder path component as album name. You can customize the name of the created albums with `makeAlbums.use`.
+
+Available options are:
+
+* `folderName`: It will use the name of the item's containing folder as Album name.
+* `folderPath`: It will use the full path of the  item's containing folder as Album name.
+
+```
+# for file: /foo/bar/xyz/file.jpg
+
+use: folderName
+# album name: xyz
+
+use: folderPath
+# album name: foo_bar_xyz
+```
 
 ### `deleteAfterUpload`
 If set to true, media will be deleted from local disk after upload. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Added
 - [CONTRIBUTING](CONTRIBUTING.md) guide line has been added.
 - New Logger package to improve log readability.
+- New flags to control CLI verbosity: `--silent` suppress all logs except Fatal ones, `--debug` enable a lot of verbosity to logs.
+- New option for Album creation: `use: folderPath` will use the full folder path as Album name. See [config documentation](.docs/configuration.md#makeAlbums). ([#150][i150])
 ### Changed
+- **ATTENTION**: To upload items, you **must** run `gphotos-uploader-cli push`. The new `push` command substitutes `gphotos-uploader-cli`, that was working in previous versions.
 - [README](README.md) has been updated fixing some typos.
+- Default log verbosity is now `INFO`, use `--debug` if you want more verbose output.
 ### Deprecated
 - Once Go 1.13 has been published, previous Go 1.11 support is deprecated. This project will maintain compatibility with the last two major versions published.
+
+[i150]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/150
 
 ## 0.8.7
 ### Changed
@@ -22,7 +28,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Changed
 - Remove `build` from version. Now `version` has all the tag+build information.
 ### Fixed
-- Fix duplicated album creation. (#135)
+- Fix duplicated album creation. ([#135][i135])
+
+[i135]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/135
 
 ## 0.8.5
 ### Fixed

--- a/app/app.go
+++ b/app/app.go
@@ -11,7 +11,7 @@ type App struct {
 	TokenManager  TokenManager
 	UploadTracker UploadTracker
 
-	Log log.Logger
+	Logger log.Logger
 }
 
 type FileTracker interface {

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -27,7 +27,7 @@ func newHTTPClient() *http.Client {
 func (app *App) NewOAuth2Client(ctx context.Context, oauth2Config oauth2.Config, account string) (*http.Client, error) {
 	token, err := app.TokenManager.RetrieveToken(account)
 	if err != nil {
-		app.Log.Debugf("Token has not been retrieved from token store: %s", err)
+		app.Logger.Debugf("Token has not been retrieved from token store: %s", err)
 	}
 
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, newHTTPClient())
@@ -39,7 +39,7 @@ func (app *App) NewOAuth2Client(ctx context.Context, oauth2Config oauth2.Config,
 		}
 
 	case !token.Valid():
-		app.Log.Info("Token has been expired, refreshing")
+		app.Logger.Info("Token has been expired, refreshing")
 		token, err = oauth2Config.TokenSource(ctx, token).Token()
 		if err != nil {
 			return nil, fmt.Errorf("could not refresh the token: %s", err)
@@ -48,7 +48,7 @@ func (app *App) NewOAuth2Client(ctx context.Context, oauth2Config oauth2.Config,
 
 	// debug
 	if token != nil {
-		app.Log.Debugf("Token expiration: %s", token.Expiry.String())
+		app.Logger.Debugf("Token expiration: %s", token.Expiry.String())
 	}
 
 	// and store the token into the keyring
@@ -74,10 +74,10 @@ func (app *App) obtainOAuthTokenFromAuthServer(ctx context.Context, oauth2Config
 				return nil
 			}
 			// Open a browser to complete OAuth process.
-			app.Log.Info("Opening browser to complete authorization.")
+			app.Logger.Info("Opening browser to complete authorization.")
 			err = browser.OpenURL(url)
 			if err != nil {
-				app.Log.Warnf("Browser was not detected. Complete the authorization browsing to: %s", url)
+				app.Logger.Warnf("Browser was not detected. Complete the authorization browsing to: %s", url)
 			}
 			return nil
 		case err := <-ctx.Done():
@@ -94,7 +94,7 @@ func (app *App) obtainOAuthTokenFromAuthServer(ctx context.Context, oauth2Config
 		return err
 	})
 	if err := eg.Wait(); err != nil {
-		app.Log.Errorf("error while authorization: %s", err)
+		app.Logger.Errorf("error while authorization: %s", err)
 	}
 
 	return token, err

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -107,7 +107,12 @@ func (cmd *PushCmd) Run(cobraCmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		opt := upload.NewJobOptions(item.MakeAlbums.Enabled, item.MakeAlbums.Use, item.DeleteAfterUpload, item.UploadVideos, item.IncludePatterns, item.ExcludePatterns)
+		opt := upload.NewJobOptions(
+			item.MakeAlbums.Enabled,
+			item.MakeAlbums.Use,
+			item.DeleteAfterUpload,
+			upload.NewFilter(item.IncludePatterns, item.ExcludePatterns, item.UploadVideos),
+		)
 		job := upload.NewFolderUploadJob(gPhotos, app.FileTracker, item.SourceFolder, opt)
 
 		// get items to be uploaded

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/mgutz/ansi"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -16,10 +18,17 @@ var rootCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Short:         "Welcome to `gphotos-uploader-cli` a Google Photos uploader!",
-	PersistentPreRun: func(cobraCmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cobraCmd *cobra.Command, args []string) error {
+		if globalFlags.Silent && globalFlags.Debug {
+			return fmt.Errorf("%s and %s cannot be specified at the same time", ansi.Color("--silent", "white+b"), ansi.Color("--debug", "white+b"))
+		}
 		if globalFlags.Silent {
 			log.GetInstance().SetLevel(logrus.FatalLevel)
 		}
+		if globalFlags.Debug {
+			log.GetInstance().SetLevel(logrus.DebugLevel)
+		}
+		return nil
 	},
 	Long: `This application allows you to upload your pictures and videos to Google Photos. You can upload folders to several Google Photos accounts and organize them in albums.
 

--- a/log/log.go
+++ b/log/log.go
@@ -6,7 +6,7 @@ import (
 )
 
 var defaultLog Logger = &stdoutLogger{
-	level: logrus.DebugLevel,
+	level: logrus.InfoLevel,
 }
 
 // Discard is a logger implementation that just discards every log statement

--- a/upload/album.go
+++ b/upload/album.go
@@ -14,15 +14,7 @@ func (job *Job) albumID(path string, logger log.Logger) string {
 		return ""
 	}
 
-	var name string
-	switch job.options.createAlbumBasedOn {
-	case "folderPath":
-		name = strings.ReplaceAll(filepath.Dir(path), "/", "_")
-	case "folderName":
-	default:
-		name = filepath.Base(filepath.Dir(path))
-	}
-
+	name := albumNameUsingTemplate(path, job.options.createAlbumBasedOn)
 	if name == "" {
 		return ""
 	}
@@ -33,6 +25,36 @@ func (job *Job) albumID(path string, logger log.Logger) string {
 		return ""
 	}
 	return albumID
+}
+
+// albumNameUsingTemplate calculate the Album name for a given path based on full folder path (folderPath)
+// or folder name (folderName).
+func albumNameUsingTemplate(path, template string) string {
+	switch template {
+	case "folderPath":
+		return albumNameUsingFolderPath(path)
+	case "folderName":
+		return albumNameUsingFolderName(path)
+	}
+	return ""
+}
+
+// albumNameUsingFolderPath returns an Album name using the full path of the given folder.
+func albumNameUsingFolderPath(path string) string {
+	p := filepath.Dir(path)
+	if p == "." {
+		return ""
+	}
+	return strings.ReplaceAll(p, "/", "_")
+}
+
+// albumNameUsingFolderName returns an Album name using the name of the given folder.
+func albumNameUsingFolderName(path string) string {
+	p := filepath.Dir(path)
+	if p == "." {
+		return ""
+	}
+	return filepath.Base(path)
 }
 
 // createAlbumInGPhotos returns the ID of an album with the specified name or error if fails.

--- a/upload/album.go
+++ b/upload/album.go
@@ -54,7 +54,7 @@ func albumNameUsingFolderName(path string) string {
 	if p == "." {
 		return ""
 	}
-	return filepath.Base(path)
+	return filepath.Base(p)
 }
 
 // createAlbumInGPhotos returns the ID of an album with the specified name or error if fails.

--- a/upload/album.go
+++ b/upload/album.go
@@ -1,0 +1,47 @@
+package upload
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/gphotosuploader/gphotos-uploader-cli/log"
+)
+
+// albumID returns the album ID if MakeAlbums is enabled
+func (job *Job) albumID(path string, logger log.Logger) string {
+	if !job.options.createAlbum {
+		return ""
+	}
+
+	var name string
+	switch job.options.createAlbumBasedOn {
+	case "folderPath":
+		name = strings.ReplaceAll(filepath.Dir(path), "/", "_")
+	case "folderName":
+	default:
+		name = filepath.Base(filepath.Dir(path))
+	}
+
+	if name == "" {
+		return ""
+	}
+
+	albumID, err := job.createAlbumInGPhotos(name)
+	if err != nil {
+		logger.Error(err)
+		return ""
+	}
+	return albumID
+}
+
+// createAlbumInGPhotos returns the ID of an album with the specified name or error if fails.
+// If the album didn't exist, it's created thanks to GetOrCreateAlbumByName().
+func (job *Job) createAlbumInGPhotos(name string) (string, error) {
+	// get album ID from Google Photos API
+	album, err := job.gPhotos.GetOrCreateAlbumByName(name)
+	if err != nil {
+		return "", fmt.Errorf("album creation failed: name=%s, error=%s", name, err)
+	}
+	return album.Id, nil
+}

--- a/upload/album_test.go
+++ b/upload/album_test.go
@@ -4,10 +4,30 @@ import (
 	"testing"
 )
 
+func TestAlbumNameUsingTemplate(t *testing.T) {
+	var testData = []struct {
+		in       string
+		template string
+		out      string
+	}{
+		{in: "foo/bar/xyz", template: "folderPath", out: "foo_bar"},
+		{in: "foo/bar/xyz", template: "folderName", out: "bar"},
+		{in: "foo/bar/xyz/file", template: "folderPath", out: "foo_bar_xyz"},
+		{in: "foo/bar/xyz/file", template: "folderName", out: "xyz"},
+		{in: "foo/bar/xyz", template: "invalidTemplate", out: ""},
+	}
+	for _, tt := range testData {
+		got := albumNameUsingTemplate(tt.in, tt.template)
+		if got != tt.out {
+			t.Errorf("albumNameUsingTemplate for '%s' failed: in: '%s', expected '%s', got '%s'", tt.template, tt.in, tt.out, got)
+		}
+	}
+}
+
 func TestAlbumNameUsingFolderPath(t *testing.T) {
 	var testData = []struct {
-		in   string
-		out  string
+		in  string
+		out string
 	}{
 		{in: "", out: ""},
 		{in: "foo", out: ""},
@@ -21,18 +41,17 @@ func TestAlbumNameUsingFolderPath(t *testing.T) {
 			t.Errorf("albumNameUsingFolderPath for '%s' failed: expected '%s', got '%s'", tt.in, tt.out, got)
 		}
 	}
-
 }
 
 func TestAlbumNameUsingFolderName(t *testing.T) {
 	var testData = []struct {
-		in   string
-		out  string
+		in  string
+		out string
 	}{
 		{in: "", out: ""},
 		{in: "foo", out: ""},
 		{in: "foo/", out: "foo"},
-		{in: "foo/bar", out: "bar"},
+		{in: "foo/bar", out: "foo"},
 		{in: "foo/bar/", out: "bar"},
 	}
 	for _, tt := range testData {
@@ -42,4 +61,3 @@ func TestAlbumNameUsingFolderName(t *testing.T) {
 		}
 	}
 }
-

--- a/upload/album_test.go
+++ b/upload/album_test.go
@@ -1,0 +1,45 @@
+package upload
+
+import (
+	"testing"
+)
+
+func TestAlbumNameUsingFolderPath(t *testing.T) {
+	var testData = []struct {
+		in   string
+		out  string
+	}{
+		{in: "", out: ""},
+		{in: "foo", out: ""},
+		{in: "foo/", out: "foo"},
+		{in: "foo/bar", out: "foo"},
+		{in: "foo/bar/", out: "foo_bar"},
+	}
+	for _, tt := range testData {
+		got := albumNameUsingFolderPath(tt.in)
+		if got != tt.out {
+			t.Errorf("albumNameUsingFolderPath for '%s' failed: expected '%s', got '%s'", tt.in, tt.out, got)
+		}
+	}
+
+}
+
+func TestAlbumNameUsingFolderName(t *testing.T) {
+	var testData = []struct {
+		in   string
+		out  string
+	}{
+		{in: "", out: ""},
+		{in: "foo", out: ""},
+		{in: "foo/", out: "foo"},
+		{in: "foo/bar", out: "bar"},
+		{in: "foo/bar/", out: "bar"},
+	}
+	for _, tt := range testData {
+		got := albumNameUsingFolderName(tt.in)
+		if got != tt.out {
+			t.Errorf("albumNameUsingFolderName for '%s' failed: expected '%s', got '%s'", tt.in, tt.out, got)
+		}
+	}
+}
+

--- a/upload/filter.go
+++ b/upload/filter.go
@@ -61,8 +61,6 @@ func NewFilter(includePatterns []string, excludePatterns []string, allowVideos b
 
 // IsAllowed returns if an item should be uploaded.
 // That means:
-//   - item is a file
-//   - item is a not a video if allowVideos is not enabled
 //   - item is in the include pattern
 //   - item is not in the exclude pattern
 func (f *Filter) IsAllowed(fp string) bool {
@@ -70,10 +68,7 @@ func (f *Filter) IsAllowed(fp string) bool {
 	if f.isIncluded(fp) && !f.isExcluded(fp) {
 		return true
 	}
-
-	log.Printf("config doesn't allow to upload this item - skipping: file=%s", fp)
 	return false
-
 }
 
 func translatePatterns(pat []string) []string {

--- a/upload/folderUploadJob.go
+++ b/upload/folderUploadJob.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	gphotos "github.com/gphotosuploader/google-photos-api-client-go/lib-gphotos"
 
@@ -23,21 +24,23 @@ type Job struct {
 
 // JobOptions represents all the options that a job can have
 type JobOptions struct {
-	createAlbum       bool
-	deleteAfterUpload bool
-	uploadVideos      bool
-	includePatterns   []string
-	excludePatterns   []string
+	createAlbum        bool
+	createAlbumBasedOn string
+	deleteAfterUpload  bool
+	uploadVideos       bool
+	includePatterns    []string
+	excludePatterns    []string
 }
 
 // NewJobOptions create a jobOptions based on the submitted / validated data
-func NewJobOptions(createAlbum bool, deleteAfterUpload bool, uploadVideos bool, includePatterns []string, excludePatterns []string) *JobOptions {
+func NewJobOptions(createAlbum bool, createAlbumBasedOn string, deleteAfterUpload bool, uploadVideos bool, includePatterns []string, excludePatterns []string) *JobOptions {
 	return &JobOptions{
-		createAlbum:       createAlbum,
-		deleteAfterUpload: deleteAfterUpload,
-		uploadVideos:      uploadVideos,
-		includePatterns:   includePatterns,
-		excludePatterns:   excludePatterns,
+		createAlbum:        createAlbum,
+		createAlbumBasedOn: createAlbumBasedOn,
+		deleteAfterUpload:  deleteAfterUpload,
+		uploadVideos:       uploadVideos,
+		includePatterns:    includePatterns,
+		excludePatterns:    excludePatterns,
 	}
 }
 
@@ -52,88 +55,90 @@ func NewFolderUploadJob(gPhotos *gphotos.Client, fileTracker app.FileTracker, fp
 	}
 }
 
-// ScanFolder uploads folder
-func (job *Job) ScanFolder(uploadChan chan<- *Item, log log.Logger) error {
-	var err error
-
-	if !filesystem.IsDir(job.sourceFolder) {
-		return fmt.Errorf("%s is not a folder", job.sourceFolder)
-	}
-
+// ScanFolder return the list of Items{} to be uploaded. It scans the folder and skip
+// non allowed files (includePatterns & excludePattens).
+func (job *Job) ScanFolder(logger log.Logger) ([]Item, error) {
 	filter := NewFilter(job.options.includePatterns, job.options.excludePatterns, job.options.uploadVideos)
 
-	// dirs are walked depth-first.   These vars hold the active album
-	// default empty album for makeAlbums.enabled = false
-	errW := filepath.Walk(job.sourceFolder, func(fp string, fi os.FileInfo, errP error) error {
-		if err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "error for %v: %v\n", fp, err)
-			return nil
-		}
+	var result []Item
+	err := filepath.Walk(job.sourceFolder, job.createUploadItemListFn(&result, filter, logger))
+	return result, err
+}
+
+func (job *Job) createUploadItemListFn(items *[]Item, filter *Filter, logger log.Logger) filepath.WalkFunc {
+	return func(fp string, fi os.FileInfo, errP error) error {
 		if fi == nil {
-			_, _ = fmt.Fprintf(os.Stderr, "error for %v: FileInfo is nil\n", fp)
+			logger.Fatalf("error scanning: folder=%s, err=FileInfo is nil", fp)
 			return nil
 		}
 
-		// check if the item should be uploaded (it's a file and it's not exclude
-		if !filter.IsAllowed(fp) {
-			if fi.IsDir() {
-				return filepath.SkipDir
-			}
+		// avoid processing folders
+		if fi.IsDir() {
 			return nil
 		}
 
-		// only files are allowed
-		if !filesystem.IsFile(fp) {
+		// check if the item should be uploaded given the include and exclude patterns in the
+		// configuration file. It uses relative path from the source folder path to facilitate
+		// then set up of includePatterns and excludePatterns.
+		relativePath := filesystem.RelativePath(job.sourceFolder, fp)
+		if !filter.IsAllowed(relativePath) {
+			logger.Infof("Not allowed by config: %s: skipping file...", fp)
 			return nil
 		}
 
 		// check completed uploads db for previous uploads
 		isAlreadyUploaded, err := job.fileTracker.IsAlreadyUploaded(fp)
 		if err != nil {
-			log.Error(err)
+			logger.Error(err)
 		} else if isAlreadyUploaded {
-			log.Debugf("Already uploaded: %s: skipping file...", fp)
+			logger.Debugf("Already uploaded: %s: skipping file...", fp)
 			return nil
 		}
+
+		logger.Infof("Adding new item to upload list: item=%s, rel=%s", fp, relativePath)
 
 		// calculate Album from the folder name, we create if it's not exists
 		var albumID string
 		if job.options.createAlbum {
-			name := filepath.Base(filepath.Dir(fp))
-			albumID = getGooglePhotosAlbumID(name, job.gPhotos, log)
+			albumID, err = job.createAlbum(relativePath)
+			if err != nil {
+				logger.Error(err)
+			}
 		}
 
 		// set file upload options depending on folder upload options
-		var uploadItem = &Item{
+		var uploadItem = Item{
 			gPhotos:         job.gPhotos,
 			path:            fp,
 			album:           albumID,
 			deleteOnSuccess: job.options.deleteAfterUpload,
 		}
 
-		// finally, add the file upload to the queue
-		uploadChan <- uploadItem
-
+		*items = append(*items, uploadItem)
 		return nil
-	})
-	if errW != nil {
-		log.Errorf("walk error err=%s", errW)
 	}
-
-	return nil
 }
 
-// getGooglePhotosAlbumID returns the ID of an album with the specified name.
+// createAlbum returns the ID of an album with the specified name or error if fails.
 // If the album didn't exist, it's created thanks to GetOrCreateAlbumByName().
-func getGooglePhotosAlbumID(name string, c *gphotos.Client, log log.Logger) string {
-	if name == "" {
-		return ""
+func (job *Job) createAlbum(path string) (string, error) {
+	var name string
+	switch job.options.createAlbumBasedOn {
+	case "folderPath":
+		name = strings.ReplaceAll(filepath.Dir(path), "/", "_")
+	case "folderName":
+	default:
+		name = filepath.Base(filepath.Dir(path))
 	}
 
-	album, err := c.GetOrCreateAlbumByName(name)
-	if err != nil {
-		log.Warnf("Album creation failed: name=%s, error=%v", name, err)
-		return ""
+	if name == "" {
+		return "", nil
 	}
-	return album.Id
+
+	// get album ID from Google Photos API
+	album, err := job.gPhotos.GetOrCreateAlbumByName(name)
+	if err != nil {
+		return "", fmt.Errorf("album creation failed: name=%s, error=%s", name, err)
+	}
+	return album.Id, nil
 }

--- a/upload/folderUploadJob.go
+++ b/upload/folderUploadJob.go
@@ -61,13 +61,7 @@ func (job *Job) ScanFolder(logger log.Logger) ([]Item, error) {
 
 func (job *Job) createUploadItemListFn(items *[]Item, filter *Filter, logger log.Logger) filepath.WalkFunc {
 	return func(fp string, fi os.FileInfo, errP error) error {
-		if fi == nil {
-			logger.Fatalf("error scanning: folder=%s, err=FileInfo is nil", fp)
-			return nil
-		}
-
-		// avoid processing folders
-		if fi.IsDir() {
+		if fi == nil || fi.IsDir() {
 			return nil
 		}
 

--- a/upload/folderUploadJob.go
+++ b/upload/folderUploadJob.go
@@ -27,20 +27,16 @@ type JobOptions struct {
 	createAlbum        bool
 	createAlbumBasedOn string
 	deleteAfterUpload  bool
-	uploadVideos       bool
-	includePatterns    []string
-	excludePatterns    []string
+	filter             *Filter
 }
 
 // NewJobOptions create a jobOptions based on the submitted / validated data
-func NewJobOptions(createAlbum bool, createAlbumBasedOn string, deleteAfterUpload bool, uploadVideos bool, includePatterns []string, excludePatterns []string) *JobOptions {
+func NewJobOptions(createAlbum bool, createAlbumBasedOn string, deleteAfterUpload bool, filter *Filter) *JobOptions {
 	return &JobOptions{
 		createAlbum:        createAlbum,
 		createAlbumBasedOn: createAlbumBasedOn,
 		deleteAfterUpload:  deleteAfterUpload,
-		uploadVideos:       uploadVideos,
-		includePatterns:    includePatterns,
-		excludePatterns:    excludePatterns,
+		filter:             filter,
 	}
 }
 
@@ -58,10 +54,8 @@ func NewFolderUploadJob(gPhotos *gphotos.Client, fileTracker app.FileTracker, fp
 // ScanFolder return the list of Items{} to be uploaded. It scans the folder and skip
 // non allowed files (includePatterns & excludePattens).
 func (job *Job) ScanFolder(logger log.Logger) ([]Item, error) {
-	filter := NewFilter(job.options.includePatterns, job.options.excludePatterns, job.options.uploadVideos)
-
 	var result []Item
-	err := filepath.Walk(job.sourceFolder, job.createUploadItemListFn(&result, filter, logger))
+	err := filepath.Walk(job.sourceFolder, job.createUploadItemListFn(&result, job.options.filter, logger))
 	return result, err
 }
 

--- a/utils/filesystem/filesystem.go
+++ b/utils/filesystem/filesystem.go
@@ -28,6 +28,20 @@ func AbsolutePath(path string) (string, error) {
 	return filepath.Abs(path)
 }
 
+// RelativePath returns a path relative to the given base path. If the path is not
+// under the given base path, the specified path is returned. So all returned paths
+// are under the base path.
+func RelativePath(basepath, path string) string {
+	rp, err := filepath.Rel(basepath, path)
+	if err != nil {
+		return path
+	}
+	if strings.HasPrefix(rp, "../") {
+		return path
+	}
+	return rp
+}
+
 // IsFile asserts there is a file at path
 func IsFile(path string) bool {
 	fi, err := os.Stat(path)

--- a/utils/filesystem/filesystem_test.go
+++ b/utils/filesystem/filesystem_test.go
@@ -132,3 +132,27 @@ func TestIsDir(t *testing.T) {
 		}
 	}
 }
+
+func TestRelativePath(t *testing.T) {
+	var objectsTest = []struct {
+		base string
+		in   string
+		out  string
+	}{
+		{base: "/foo/bar", in: "/foo/bar/xyz", out: "xyz"},
+		{base: "/foo/bar/", in: "/foo/bar/xyz", out: "xyz"},
+		{base: "/foo/bar", in: "/foo/bar/xyz/", out: "xyz"},
+		{base: "/foo/bar", in: "foo/bar/xyz", out: "foo/bar/xyz"},
+		{base: "/foo/bar", in: "/foo/bar", out: "."},
+		{base: "/foo/bar/", in: "/foo/bar", out: "."},
+		{base: "/foo/bar", in: "/foo/bar/", out: "."},
+		{base: "", in: "/foo/bar", out: "/foo/bar"},
+		{base: "/foo/bar", in: "/abc/def", out: "/abc/def"},
+	}
+	for _, tt := range objectsTest {
+		got := filesystem.RelativePath(tt.base, tt.in)
+		if got != tt.out {
+			t.Errorf("failed for base '%s', path '%s': expected '%s', got '%s'", tt.base, tt.in, tt.out, got)
+		}
+	}
+}


### PR DESCRIPTION
**What issue type does this pull request address?**
enhancement

**What is this pull request for? Which issues does it resolve?** 
This issue adds three different things:
1. Add a new `push` command to upload objects to Google Photos. Deprecating `gphotos-uploader-cli` wo/ command.
2. Add `--silent` and `--debug` flags to control output verbosity.
3. Add a configuration option to create Album names based on full folder path. Resolves #150 

**Does this pull request has user-facing changes?** 
- The CLI **must** run with `push` command: `gphotos-uploader-push`.
- New configuration options are available. See [documentation](https://github.com/gphotosuploader/gphotos-uploader-cli/blob/master/.docs/configuration.md)

**What else do we need to know?**  
- Add a breaking change. Now you **must** run the CLI with a command.