### PR TITLE
Fix issue #158: Uploading objects without the proper file name on Google Photos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.0.0-alpha.2
+> This is a **major upgrade** and it has several **non-backwards compatible changes**. See more details below.
+### Fix
+- Fix issue uploading photos without the correct file name. ([#158][i158])
+
+[i158]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/158
+
 ## 1.0.0-alpha.1
 > This is a **major upgrade** and it has several **non-backwards compatible changes**. See more details below.
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/99designs/keyring v1.1.2
 	github.com/client9/xson v0.0.0-20180321172152-0e50cdfc08c0
-	github.com/gphotosuploader/google-photos-api-client-go v1.1.2
+	github.com/gphotosuploader/google-photos-api-client-go v1.1.3
 	github.com/gphotosuploader/googlemirror v0.3.2
 	github.com/int128/oauth2cli v1.7.0
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/gphotosuploader/google-photos-api-client-go v1.1.2 h1:11VDD+ZkxyxMphC/C8IBQsscOVwBf5MaHJZYCu2k1so=
 github.com/gphotosuploader/google-photos-api-client-go v1.1.2/go.mod h1:drQlpEncMykB/tPjsr0TKUKAfGKCOqg5Zl0XLuEopfA=
+github.com/gphotosuploader/google-photos-api-client-go v1.1.3 h1:FWyu43osmTcjbUpP+tcVKCxhNGFsi1GvG8TmIYYTqok=
+github.com/gphotosuploader/google-photos-api-client-go v1.1.3/go.mod h1:WgKsL9SxFf1zdQqCzR6olqaCyv1r5dDK64bceeRmt+I=
 github.com/gphotosuploader/googlemirror v0.3.2 h1:xaYVJYEDj2rYMYGi5sTGMy6gkD5PVKfz4c3ZW8gQs+M=
 github.com/gphotosuploader/googlemirror v0.3.2/go.mod h1:725+/afSOVU01M2Lfi3NIw8L3Oupjit6u/s1MLjK160=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=


### PR DESCRIPTION
**What issue type does this pull request address?** 
bug

**What is this pull request for? Which issues does it resolve?**
resolves #158 
