### PR TITLE
Add a new command to refresh tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.0.1
+### Added
+- New command `auth` to authenticate against Google Photos. It's useful to refresh authentication tokens.
+
 ## 1.0.0
 > This is a **major upgrade** and it has several **non-backwards compatible changes**. See more details below.
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 
 ## 1.0.1
 ### Added
-- New command `auth` to authenticate against Google Photos. It's useful to refresh authentication tokens.
+- New command `auth` to authenticate against Google Photos. It's useful to refresh authentication tokens. ([#125][i125])
+
+[i125]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/125
 
 ## 1.0.0
 > This is a **major upgrade** and it has several **non-backwards compatible changes**. See more details below.

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -56,8 +56,7 @@ func (cmd *AuthCmd) Run(cobraCmd *cobra.Command, args []string) error {
 
 	ctx := context.Background()
 	for _, job := range cfg.Jobs {
-		_, err := cli.NewOAuth2Client(ctx, oauth2Config, job.Account)
-		if err != nil {
+		if _, err := cli.NewOAuth2Client(ctx, oauth2Config, job.Account); err != nil {
 			cli.Logger.Failf("Failed authentication for account: %s", job.Account)
 			cli.Logger.Debugf("Authentication error: err=%s", err)
 			return err
@@ -67,4 +66,6 @@ func (cmd *AuthCmd) Run(cobraCmd *cobra.Command, args []string) error {
 
 	return nil
 }
+
+
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+
+	"github.com/gphotosuploader/gphotos-uploader-cli/app"
+	"github.com/gphotosuploader/gphotos-uploader-cli/cmd/flags"
+	"github.com/gphotosuploader/gphotos-uploader-cli/config"
+	"github.com/gphotosuploader/gphotos-uploader-cli/photos"
+)
+
+// InitCmd holds the required data for the init cmd
+type AuthCmd struct {
+	*flags.GlobalFlags
+}
+
+func NewAuthCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &AuthCmd{GlobalFlags: globalFlags}
+
+	authCmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Authenticate with Google Photos to refresh tokens",
+		Long:  `Force authentication against Google Photos to refresh tokens.`,
+		Args:  cobra.NoArgs,
+		RunE:  cmd.Run,
+	}
+
+	return authCmd
+}
+
+func (cmd *AuthCmd) Run(cobraCmd *cobra.Command, args []string) error {
+	cfg, err := config.LoadConfigAndValidate(cmd.CfgDir)
+	if err != nil {
+		return fmt.Errorf("please review your configuration or run 'gphotos-uploader-cli init': file=%s, err=%s", cmd.CfgDir, err)
+	}
+
+	cli, err := app.Start(cfg)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = cli.Stop()
+	}()
+
+	// get OAuth2 Configuration with our App credentials
+	oauth2Config := oauth2.Config{
+		ClientID:     cfg.APIAppCredentials.ClientID,
+		ClientSecret: cfg.APIAppCredentials.ClientSecret,
+		Endpoint:     photos.Endpoint,
+		Scopes:       photos.Scopes,
+	}
+
+	ctx := context.Background()
+	for _, job := range cfg.Jobs {
+		_, err := cli.NewOAuth2Client(ctx, oauth2Config, job.Account)
+		if err != nil {
+			cli.Logger.Failf("Failed authentication for account: %s", job.Account)
+			cli.Logger.Debugf("Authentication error: err=%s", err)
+			return err
+		}
+		cli.Logger.Donef("Successful authentication for account: %s", job.Account)
+	}
+
+	return nil
+}
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,6 +64,7 @@ func init() {
 	rootCmd.AddCommand(NewVersionCmd())
 	rootCmd.AddCommand(NewInitCmd(globalFlags))
 	rootCmd.AddCommand(NewPushCmd(globalFlags))
+	rootCmd.AddCommand(NewAuthCmd(globalFlags))
 }
 
 // GetRoot returns the root command


### PR DESCRIPTION
**What issue type does this pull request address?** 
feature

**What is this pull request for? Which issues does it resolve?** 
`gphotos-uploader-cli auth` command could be used to refresh authorization tokens agains Google Photos.
resolves #125 


**Does this pull request has user-facing changes?** 
A `auth` command is added to allow user to refresh authorization tokens.
