### PR TITLE
Make task submission to work in a different subroutine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.0.2
+### Fixed
+- Fix issue that hung the application when the `results` queue was full. This happened every time that the number of files to upload was higher than 10x number of concurrent processes. ([#167][i167])
+
+[i167]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/167
+
 ## 1.0.1
 ### Added
 - New command `auth` to authenticate against Google Photos. It's useful to refresh authentication tokens. ([#125][i125])

--- a/worker/queue.go
+++ b/worker/queue.go
@@ -104,9 +104,9 @@ func (q *JobQueue) dispatch() {
 	}
 }
 
-// Submit - adds a new job to be processed, uses another function to prevent blocking
+// Submit - adds a new job to be processed, uses a subroutine to avoid deadlock when the queue is full
 func (q *JobQueue) Submit(job Job) {
-	q.internalQueue <- job
+	go func(job Job) { q.internalQueue <- job }(job)
 }
 
 // NewWorker - creates a new worker

--- a/worker/queue_test.go
+++ b/worker/queue_test.go
@@ -31,8 +31,10 @@ func TestQueue(t *testing.T) {
 		{numberOfWorkers: 1, numberOfJobs: 1, want: 1000},
 		{numberOfWorkers: 1, numberOfJobs: 2, want: 2000},
 		{numberOfWorkers: 1, numberOfJobs: 5, want: 5000},
+		{numberOfWorkers: 1, numberOfJobs: 20, want: 20000},
 		{numberOfWorkers: 5, numberOfJobs: 5, want: 5000},
 		{numberOfWorkers: 5, numberOfJobs: 50, want: 50000},
+		{numberOfWorkers: 5, numberOfJobs: 100, want: 100000},
 	}
 
 	var logger = log.Discard


### PR DESCRIPTION
**What issue type does this pull request address?** 
/kind bug

**What is this pull request for? Which issues does it resolve?**
The provided queue was using a buffered channel to put the workers results, this channel had a capacity or `numberOfWorkers * 10`, so in cases were the number of tasks was very high, the application was blocked waiting to be able consume `results channel`.

We have moved task submission to a different go routine, so this is not happening any more. Two tests has been added for this specific case.

resolves #167 

**Does this pull request has user-facing changes?**
No
