### PR TITLE
Fix 'init' error when it was used with root folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.0.4
+### Fixed
+- Fix `init` command error when it was used with root folders. ([#172][i172])
+
+[i170]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/172
+
 ## 1.0.3
 ### Fixed
 - Fix inconsistent use of `folderName` configuration option. ([#170][i170])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Fixed
 - Fix `init` command error when it was used with root folders. ([#172][i172])
 
-[i170]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/172
+[i172]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/172
 
 ## 1.0.3
 ### Fixed

--- a/config/config.go
+++ b/config/config.go
@@ -129,9 +129,26 @@ func (c *Config) String() string {
 		c.Jobs[0].UploadVideos)
 }
 
-// LoadConfig reads configuration from the specified directory.
+func (c *Config) WriteToFile() error {
+	fh, err := os.Create(c.ConfigFile())
+	if err != nil {
+		return fmt.Errorf("failed to create config: file=%s, err=%v", c.ConfigFile(), err)
+	}
+	defer func() {
+		_ = fh.Close()
+	}()
+
+	_, err = fh.WriteString(c.String())
+	if err != nil {
+		return fmt.Errorf("failed to write configuration: file=%s, err=%v", c.ConfigFile(), err)
+	}
+
+	return fh.Sync()
+}
+
+// LoadConfigFromFile reads configuration from the specified directory.
 // It reads a HJSON file (given by config.ConfigFile() func) and decodes it.
-func LoadConfig(dir string) (*Config, error) {
+func LoadConfigFromFile(dir string) (*Config, error) {
 	cfg := NewConfig(dir)
 
 	data, err := ioutil.ReadFile(cfg.ConfigFile())
@@ -146,13 +163,13 @@ func LoadConfig(dir string) (*Config, error) {
 	return cfg, nil
 }
 
+// LoadConfigAndValidate reads configuration from the specified directory and validate it.
 func LoadConfigAndValidate(dir string) (*Config, error) {
-	cfg, err := LoadConfig(dir)
+	cfg, err := LoadConfigFromFile(dir)
 	if err != nil {
 		return cfg, fmt.Errorf("could't read configuration: file=%s, err=%s", dir, err)
 	}
-	err = cfg.Validate()
-	if err != nil {
+	if err = cfg.Validate(); err != nil {
 		return cfg, fmt.Errorf("invalid configuration: file=%s, err=%s", cfg.ConfigFile(), err)
 	}
 	return cfg, nil
@@ -166,20 +183,7 @@ func InitConfigFile(dir string) error {
 		return fmt.Errorf("failed to create config directory: path=%s, err=%v", cfg.ConfigPath, err)
 	}
 
-	fh, err := os.Create(cfg.ConfigFile())
-	if err != nil {
-		return fmt.Errorf("failed to create config: file=%s, err=%v", cfg.ConfigFile(), err)
-	}
-	defer func() {
-		_ = fh.Close()
-	}()
-
-	_, err = fh.WriteString(cfg.String())
-	if err != nil {
-		return fmt.Errorf("failed to write configuration: file=%s, err=%v", cfg.ConfigFile(), err)
-	}
-
-	return fh.Sync()
+	return cfg.WriteToFile()
 }
 
 // ConfigExists checks if a gphotos-uplaoder-cli configuration exists at a certain path

--- a/config/config.go
+++ b/config/config.go
@@ -162,16 +162,8 @@ func LoadConfigAndValidate(dir string) (*Config, error) {
 func InitConfigFile(dir string) error {
 	cfg := NewConfig(dir)
 
-	if !filesystem.IsDir(dir) {
-		err := os.MkdirAll(cfg.ConfigPath, 0755)
-		if err != nil {
-			return fmt.Errorf("failed to create config directory: path=%s, err=%v", cfg.ConfigPath, err)
-		}
-	}
-
-	err := filesystem.RemoveDirContent(dir)
-	if err != nil {
-		return fmt.Errorf("failed to remove config directory: path=%s, err=%v", cfg.ConfigPath, err)
+	if err := filesystem.EmptyOrCreateDir(cfg.ConfigPath); err != nil {
+		return fmt.Errorf("failed to create config directory: path=%s, err=%v", cfg.ConfigPath, err)
 	}
 
 	fh, err := os.Create(cfg.ConfigFile())

--- a/config/config.go
+++ b/config/config.go
@@ -132,11 +132,9 @@ func (c *Config) String() string {
 func (c *Config) WriteToFile() error {
 	fh, err := os.Create(c.ConfigFile())
 	if err != nil {
-		return fmt.Errorf("failed to create config: file=%s, err=%v", c.ConfigFile(), err)
+		return err
 	}
-	defer func() {
-		_ = fh.Close()
-	}()
+	defer fh.Close()
 
 	_, err = fh.WriteString(c.String())
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -162,15 +162,16 @@ func LoadConfigAndValidate(dir string) (*Config, error) {
 func InitConfigFile(dir string) error {
 	cfg := NewConfig(dir)
 
-	// Delete config & overwrite config
-	err := os.RemoveAll(dir)
-	if err != nil {
-		return err
+	if !filesystem.IsDir(dir) {
+		err := os.MkdirAll(cfg.ConfigPath, 0755)
+		if err != nil {
+			return fmt.Errorf("failed to create config directory: path=%s, err=%v", cfg.ConfigPath, err)
+		}
 	}
 
-	err = os.MkdirAll(cfg.ConfigPath, 0755)
+	err := filesystem.RemoveDirContent(dir)
 	if err != nil {
-		return fmt.Errorf("failed to create config directory: path=%s, err=%v", cfg.ConfigPath, err)
+		return fmt.Errorf("failed to remove config directory: path=%s, err=%v", cfg.ConfigPath, err)
 	}
 
 	fh, err := os.Create(cfg.ConfigFile())

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.12
 
 require (
 	github.com/99designs/keyring v1.1.2
+	github.com/Flaque/filet v0.0.0-20190209224823-fc4d33cfcf93
 	github.com/client9/xson v0.0.0-20180321172152-0e50cdfc08c0
 	github.com/gphotosuploader/google-photos-api-client-go v1.1.3
 	github.com/gphotosuploader/googlemirror v0.3.2
 	github.com/int128/oauth2cli v1.7.0
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
-	github.com/nmrshll/go-cp v0.0.0-20180115193924-61436d3b7cfa
 	github.com/pierrec/xxHash v0.1.5
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSR
 github.com/99designs/keyring v1.1.2 h1:JJauROcU6x6Nh9uZb+8JgXFvyo0GUESLo1ixhpA0Kmw=
 github.com/99designs/keyring v1.1.2/go.mod h1:657DQuMrBZRtuL/voxVyiyb6zpMehlm5vLB9Qwrv904=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Flaque/filet v0.0.0-20190209224823-fc4d33cfcf93 h1:NnAUCP75PRm8yWE7+MZBIAR6PA9iwsBYEc6ZNYOy+AQ=
+github.com/Flaque/filet v0.0.0-20190209224823-fc4d33cfcf93/go.mod h1:TK+jB3mBs+8ZMWhU5BqZKnZWJ1MrLo8etNVg51ueTBo=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/client9/xson v0.0.0-20180321172152-0e50cdfc08c0 h1:dDDdcbYxoxlR7iYTJ3XT6d/qIqYW2KE9PWBu4kYCYXM=
@@ -39,8 +41,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
-github.com/gphotosuploader/google-photos-api-client-go v1.1.2 h1:11VDD+ZkxyxMphC/C8IBQsscOVwBf5MaHJZYCu2k1so=
-github.com/gphotosuploader/google-photos-api-client-go v1.1.2/go.mod h1:drQlpEncMykB/tPjsr0TKUKAfGKCOqg5Zl0XLuEopfA=
 github.com/gphotosuploader/google-photos-api-client-go v1.1.3 h1:FWyu43osmTcjbUpP+tcVKCxhNGFsi1GvG8TmIYYTqok=
 github.com/gphotosuploader/google-photos-api-client-go v1.1.3/go.mod h1:WgKsL9SxFf1zdQqCzR6olqaCyv1r5dDK64bceeRmt+I=
 github.com/gphotosuploader/googlemirror v0.3.2 h1:xaYVJYEDj2rYMYGi5sTGMy6gkD5PVKfz4c3ZW8gQs+M=
@@ -81,8 +81,6 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyex
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/nmrshll/go-cp v0.0.0-20180115193924-61436d3b7cfa h1:/SRdH7jdcIW6WBtZO1BlpI+6TxqpOiMqLZJ10Uhk0k0=
-github.com/nmrshll/go-cp v0.0.0-20180115193924-61436d3b7cfa/go.mod h1:/Uh/WFiWYXoTKVsM302U10XnogAldY7up/xErXmt1FA=
 github.com/nmrshll/oauth2-noserver v0.0.0-20190221200101-9bf017bef639/go.mod h1:6MfXZxM+z77B8HpksafhB216XNpQ4KMEM4583VBJMog=
 github.com/nmrshll/rndm-go v0.0.0-20170430161430-8da3024e53de/go.mod h1:OeEnWnbCrUWnPl1xSCGM5/qtWqZ4L15KOAjR/wmxhXc=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -102,6 +100,7 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/skratchdot/open-golang v0.0.0-20190402232053-79abb63cd66e/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
+github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
@@ -175,7 +174,6 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/utils/filesystem/filesystem.go
+++ b/utils/filesystem/filesystem.go
@@ -28,9 +28,9 @@ func AbsolutePath(path string) (string, error) {
 	return filepath.Abs(path)
 }
 
-// RemoveDirContent removes all files and folders inside the specified path.
+// EmptyDir removes all files and folders inside the specified path.
 // It could be similar to RemoveAll() but without removing the folder itself.
-func RemoveDirContent(path string) error {
+func EmptyDir(path string) error {
 	files, err := filepath.Glob(filepath.Join(path, "*"))
 	if err != nil {
 		return err
@@ -42,6 +42,22 @@ func RemoveDirContent(path string) error {
 		}
 	}
 	return nil
+}
+
+// CreateDirIfDoesNotExist creates a directory if the specified path does not exist
+func CreateDirIfDoesNotExist(path string) error {
+	if IsDir(path) {
+		return nil
+	}
+	return os.MkdirAll(path, 0755)
+}
+
+// EmptyOrCreateDir create a new folder or empty an existing one
+func EmptyOrCreateDir(path string) error {
+	if err := CreateDirIfDoesNotExist(path); err != nil {
+		return err
+	}
+	return EmptyDir(path)
 }
 
 // RelativePath returns a path relative to the given base path. If the path is not

--- a/utils/filesystem/filesystem.go
+++ b/utils/filesystem/filesystem.go
@@ -28,6 +28,22 @@ func AbsolutePath(path string) (string, error) {
 	return filepath.Abs(path)
 }
 
+// RemoveDirContent removes all files and folders inside the specified path.
+// It could be similar to RemoveAll() but without removing the folder itself.
+func RemoveDirContent(path string) error {
+	files, err := filepath.Glob(filepath.Join(path, "*"))
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		err = os.RemoveAll(file)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // RelativePath returns a path relative to the given base path. If the path is not
 // under the given base path, the specified path is returned. So all returned paths
 // are under the base path.

--- a/utils/filesystem/filesystem.go
+++ b/utils/filesystem/filesystem.go
@@ -17,12 +17,14 @@ func AbsolutePath(path string) (string, error) {
 	}
 	dir := usr.HomeDir
 
+	// In case of "~", which won't be caught by the next case
 	if path == "~" {
-		// In case of "~", which won't be caught by the "else if"
 		return dir, nil
-	} else if strings.HasPrefix(path, "~/") {
-		// Use strings.HasPrefix so we don't match paths like
-		// "/something/~/something/"
+	}
+
+	// Use strings.HasPrefix so we don't match paths like
+	// "/something/~/something/"
+	if strings.HasPrefix(path, "~/") {
 		return filepath.Join(dir, path[2:]), nil
 	}
 	return filepath.Abs(path)
@@ -36,8 +38,7 @@ func EmptyDir(path string) error {
 		return err
 	}
 	for _, file := range files {
-		err = os.RemoveAll(file)
-		if err != nil {
+		if err := os.RemoveAll(file); err != nil {
 			return err
 		}
 	}

--- a/utils/filesystem/filesystem_test.go
+++ b/utils/filesystem/filesystem_test.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/Flaque/filet"
+
 	"github.com/gphotosuploader/gphotos-uploader-cli/utils/filesystem"
 )
 
@@ -154,5 +156,28 @@ func TestRelativePath(t *testing.T) {
 		if got != tt.out {
 			t.Errorf("failed for base '%s', path '%s': expected '%s', got '%s'", tt.base, tt.in, tt.out, got)
 		}
+	}
+}
+
+func TestRemoveDirContent(t *testing.T) {
+	defer filet.CleanUp(t)
+
+	// create a fake config dir with a file inside of it
+	cfgDir := filet.TmpDir(t, "")
+	file := filet.TmpFile(t, cfgDir, "")
+
+	err := filesystem.RemoveDirContent(cfgDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// dir should exists after removal
+	if _, err := os.Stat(cfgDir); err != nil {
+		t.Errorf("failed: dir has been deleted, that was unexpected")
+	}
+
+	// file should not exists after removal
+	if _, err := os.Stat(file.Name()); err == nil {
+		t.Errorf("failed: there are content inside dir, that was unexpected")
 	}
 }

--- a/utils/filesystem/filesystem_test.go
+++ b/utils/filesystem/filesystem_test.go
@@ -1,10 +1,13 @@
 package filesystem_test
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"path"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Flaque/filet"
 
@@ -159,25 +162,100 @@ func TestRelativePath(t *testing.T) {
 	}
 }
 
-func TestRemoveDirContent(t *testing.T) {
+func TestEmptyDirWithOneFile(t *testing.T) {
 	defer filet.CleanUp(t)
 
-	// create a fake config dir with a file inside of it
-	cfgDir := filet.TmpDir(t, "")
-	file := filet.TmpFile(t, cfgDir, "")
+	// create a dir with a file inside of it
+	dir := filet.TmpDir(t, "")
+	file := filet.TmpFile(t, dir, "")
 
-	err := filesystem.RemoveDirContent(cfgDir)
+	err := filesystem.EmptyDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// dir should exists after removal
-	if _, err := os.Stat(cfgDir); err != nil {
+	if _, err := os.Stat(dir); err != nil {
 		t.Errorf("failed: dir has been deleted, that was unexpected")
 	}
 
 	// file should not exists after removal
 	if _, err := os.Stat(file.Name()); err == nil {
 		t.Errorf("failed: there are content inside dir, that was unexpected")
+	}
+}
+
+func TestEmptyDirWithOneDir(t *testing.T) {
+	defer filet.CleanUp(t)
+
+	// create a dir with a file inside of it
+	parentDir := filet.TmpDir(t, "")
+	childDir := filet.TmpDir(t, parentDir)
+
+	err := filesystem.EmptyDir(parentDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// parent dir should exists after removal
+	if _, err := os.Stat(parentDir); err != nil {
+		t.Errorf("failed: paret dir has been deleted, that was unexpected")
+	}
+
+	// child dir should not exists after removal
+	if _, err := os.Stat(childDir); err == nil {
+		t.Errorf("failed: there are content inside parent dir, that was unexpected")
+	}
+}
+
+func TestEmptyOrCreateDirExistingDir(t *testing.T) {
+	const numberOfIterations = 10
+	defer filet.CleanUp(t)
+
+	for i := 0; i < numberOfIterations; i++ {
+		// create a dir with a file inside of it
+		dir := filet.TmpDir(t, "")
+		file := filet.TmpFile(t, dir, "")
+
+		err := filesystem.EmptyOrCreateDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// dir should exists after removal
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("failed: dir has been deleted, that was unexpected")
+		}
+
+		// file should not exists after removal
+		if _, err := os.Stat(file.Name()); err == nil {
+			t.Errorf("failed: there are content inside dir, that was unexpected")
+		}
+	}
+}
+
+func TestEmptyOrCreateDirNonExistingDir(t *testing.T) {
+	const numberOfIterations = 10
+	var dirs [numberOfIterations]string
+
+	for i := 0; i < numberOfIterations; i++ {
+		dirs[i] = filepath.Join(os.TempDir(), fmt.Sprintf("dir-%d.%d", i, time.Now().UnixNano()))
+	}
+	defer func(dirs [numberOfIterations]string) {
+		for _, dir := range dirs {
+			_ = os.RemoveAll(dir)
+		}
+	}(dirs)
+
+	for _, dir := range dirs {
+		err := filesystem.EmptyOrCreateDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// dir should exists
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("failed: dir has been deleted, that was unexpected")
+		}
 	}
 }


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bug

**What is this pull request for? Which issues does it resolve?** 
When `init` command was used, it was removing the configuration folder, that was producing problems when the user doesn't have permission on the parent folder. With this PR the `init` command will remove the contents inside the dir without touching the dir itself.

resolves #172 


**Does this pull request has user-facing changes?** 
There is not changes.

**Does this pull request add new dependencies?**  
Add a library to deal with temporary dir and file creation for tests: [Flaque/filet](https://github.com/Flaque/filet)
