### PR TITLE
Fix  issue 181 changing the way to obtain OAuth token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 
 ## Unreleased
 ### Changed
+- Fix (temporary) OAuth broken process ([#181][i181])
 - Bump github.com/int128/oauth2cli to v1.12.1 ([#206][i206])
 - Bump golang.org/x/oauth2 to v0.0.0-20200107190931-bf48bf16ab8d ([#205][i205])
 
+[i181]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/181
 [i206]: https://github.com/gphotosuploader/gphotos-uploader-cli/pull/206
 [i205]: https://github.com/gphotosuploader/gphotos-uploader-cli/pull/205
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+### Changed
+- Bump github.com/int128/oauth2cli to v1.12.1 ([#206][i206])
+- Bump golang.org/x/oauth2 to v0.0.0-20200107190931-bf48bf16ab8d ([#205][i205])
+
+[i206]: https://github.com/gphotosuploader/gphotos-uploader-cli/pull/206
+[i205]: https://github.com/gphotosuploader/gphotos-uploader-cli/pull/205
+
 ## 1.0.6
 ### Changed
 - Updated some dependencies

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ $ gphotos-uploader-cli push
 ```
 
 ### First time run
+> NOTE: The Google Authorization process has been temporary changed due to a bug, please read how to use the new one  [here](https://github.com/gphotosuploader/gphotos-uploader-cli/issues/181#issuecomment-660625164).
+
 The first time you run `gphotos-uploader-cli`, after setting your configuration ([Google Photos API credentials](.docs/configuration.md#APIAppCredentials)), few manual steps are needed:
 
 1. You should get an output like this one:

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -6,17 +6,17 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/int128/oauth2cli"
-	"github.com/pkg/browser"
 	"golang.org/x/oauth2"
-	"golang.org/x/sync/errgroup"
 )
 
+/*
+Disabled due to the unused obtainOAuthTokenFromPAuthServer() method.
+--
 const successPage = `
 		<div style="height:100px; width:100%!; display:flex; flex-direction: column; justify-content: center; align-items:center; background-color:#2ecc71; color:white; font-size:22"><div>Success!</div></div>
 		<p style="margin-top:20px; font-size:18; text-align:center">You are authenticated, you can now return to the program. This will auto-close</p>
 		<script>window.onload=function(){setTimeout(this.close, 4000)}</script>
-		`
+		`*/
 
 func newHTTPClient() *http.Client {
 	return http.DefaultClient
@@ -95,6 +95,10 @@ func exchangeToken(ctx context.Context, config oauth2.Config, code string) (*oau
 	return config.Exchange(ctx, code)
 }
 
+/**
+Disable this method in favor of obtainOAuthTokenFromPrompt().
+In the future a global flag (e.g. --headless) should allow users to use the current one or this one.
+--
 func (app *App) obtainOAuthTokenFromAuthServer(ctx context.Context, oauth2Config oauth2.Config) (*oauth2.Token, error) {
 	app.Logger.Debug("Trying to get token from browser...")
 	var token *oauth2.Token
@@ -133,4 +137,4 @@ func (app *App) obtainOAuthTokenFromAuthServer(ctx context.Context, oauth2Config
 	}
 
 	return token, err
-}
+}*/

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/int128/oauth2cli"
 	"github.com/pkg/browser"
@@ -25,24 +26,26 @@ func newHTTPClient() *http.Client {
 // It will try to get the credentials from the Token Manager, if they are not valid will try to refresh the token or
 // ask for authenticate again.
 func (app *App) NewOAuth2Client(ctx context.Context, oauth2Config oauth2.Config, account string) (*http.Client, error) {
+	app.Logger.Debugf("Getting OAuth token for %s", account)
 	token, err := app.TokenManager.RetrieveToken(account)
 	if err != nil {
-		app.Logger.Debugf("Token has not been retrieved from token store: %s", err)
+		app.Logger.Debugf("Unable to retrieve token from token store: %s", err)
 	}
 
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, newHTTPClient())
 	switch {
 	case token == nil:
-		token, err = app.obtainOAuthTokenFromAuthServer(ctx, oauth2Config)
+		// issue-181: Forces headless authentication.
+		token, err = app.obtainOAuthTokenFromPrompt(ctx, oauth2Config)
 		if err != nil {
-			return nil, fmt.Errorf("could not get a token: %s", err)
+			return nil, fmt.Errorf("unable to get a token for %s: %s", account, err)
 		}
 
 	case !token.Valid():
 		app.Logger.Info("Token has been expired, refreshing")
 		token, err = oauth2Config.TokenSource(ctx, token).Token()
 		if err != nil {
-			return nil, fmt.Errorf("could not refresh the token: %s", err)
+			return nil, fmt.Errorf("unable to refresh the token: %s", err)
 		}
 	}
 
@@ -61,7 +64,39 @@ func (app *App) NewOAuth2Client(ctx context.Context, oauth2Config oauth2.Config,
 	return client, nil
 }
 
+func (app *App) obtainOAuthTokenFromPrompt(ctx context.Context, oauth2Config oauth2.Config) (*oauth2.Token, error) {
+	app.Logger.Debug("Trying to get token from prompt...")
+
+	oauth2Config.RedirectURL = "urn:ietf:wg:oauth:2.0:oob"
+
+	// Redirect user to consent page to ask for permission
+	// for the scopes specified above.
+	url := oauth2Config.AuthCodeURL("state", oauth2.AccessTypeOffline)
+	fmt.Printf("\nVisit the following URL in your browser:\n%v\n\n", url)
+
+	// Use the authorization code that is pushed to the redirect
+	// URL. Exchange will do the handshake to retrieve the
+	// initial access token. The HTTP Client returned by
+	// conf.Client will refresh the token as necessary.
+	var code string
+	fmt.Print("After completing the authorization flow, enter the authorization code here: ")
+	if _, err := fmt.Scanln(&code); err != nil {
+		return nil, fmt.Errorf("unable to read authorization code: %s", err)
+	}
+
+	return exchangeToken(ctx, oauth2Config, code)
+}
+
+func exchangeToken(ctx context.Context, config oauth2.Config, code string) (*oauth2.Token, error) {
+	// Use the custom HTTP client when requesting a token.
+	httpClient := &http.Client{Timeout: 2 * time.Second}
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
+
+	return config.Exchange(ctx, code)
+}
+
 func (app *App) obtainOAuthTokenFromAuthServer(ctx context.Context, oauth2Config oauth2.Config) (*oauth2.Token, error) {
+	app.Logger.Debug("Trying to get token from browser...")
 	var token *oauth2.Token
 	var err error
 
@@ -74,7 +109,7 @@ func (app *App) obtainOAuthTokenFromAuthServer(ctx context.Context, oauth2Config
 				return nil
 			}
 			// Open a browser to complete OAuth process.
-			app.Logger.Info("Opening browser to complete authorization.")
+			app.Logger.Infof("Opening browser to complete authorization: %s", url)
 			err = browser.OpenURL(url)
 			if err != nil {
 				app.Logger.Warnf("Browser was not detected. Complete the authorization browsing to: %s", url)

--- a/datastore/tokenstore/repository_keyring.go
+++ b/datastore/tokenstore/repository_keyring.go
@@ -127,8 +127,8 @@ func (r *KeyringRepository) getToken(email string) (oauth2.Token, error) {
 }
 
 
-func terminalPrompt(prompt string) (string, error) {
-	fmt.Printf("%s: ", prompt)
+func terminalPrompt(_ string) (string, error) {
+	fmt.Print("Enter the passphrase to open the token store: ")
 	b, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind bug


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #181 


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
Previously, a browser was opened to complete the OAuth flow. Since this PR a URL is shown. The user needs to visit the link, complete the OAuth flow and copy & paste the authorisation code.

This new approach is compatible with headless uses. 