### PR TITLE
Change deleteAfterUpload default value to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+### Changed
+- The `init` command sets `deleteAfterUpload: false` as default value. ([#214][i214])
+
+[i214]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/214
 
 ## 1.0.8
 ### Changed

--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,7 @@ func defaultSettings() *Config {
 			Enabled: true,
 			Use:     "folderName",
 		},
-		DeleteAfterUpload: true,
+		DeleteAfterUpload: false,
 		UploadVideos:      true,
 	}
 	c.Jobs = append(c.Jobs, job)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -175,7 +175,7 @@ func createTestConfiguration() *config.Config {
 			Enabled: true,
 			Use:     "folderName",
 		},
-		DeleteAfterUpload: true,
+		DeleteAfterUpload: false,
 		UploadVideos:      true,
 	}
 	c.Jobs = append(c.Jobs, job)


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
Relate to #214 

**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
Whe you run `gphotos-uploader-cli init` the default value for `deleteAfterUpload` has changes to `false`

