### PR TITLE
Add dry-run flag to push command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+### Added
+- Flag `--dry-run` to `push` command. It's useful to validate `includePatterns` and `excludePatterns` configuration. ([#216][i216])
+
 ### Changed
 - The `init` command sets `deleteAfterUpload: false` as default value. ([#214][i214])
 
+[i216]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/216
 [i214]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/214
 
 ## 1.0.8

--- a/upload/noopjob.go
+++ b/upload/noopjob.go
@@ -1,0 +1,11 @@
+package upload
+
+type NoOpJob struct {}
+
+func (job *NoOpJob) Process() error {
+	return nil
+}
+
+func (job *NoOpJob) ID() string {
+	return "noop"
+}

--- a/upload/walker.go
+++ b/upload/walker.go
@@ -45,7 +45,7 @@ func (job *UploadFolderJob) getItemToUploadFn(reqs *[]UploadItem, logger log.Log
 			return nil
 		}
 
-		logger.Infof("Found item to upload: %s", fp)
+		logger.Infof("File '%s' will be uploaded to album '%s'.", fp, job.albumName(relativePath))
 
 		// set file upload Options depending on folder upload Options
 		*reqs = append(*reqs, UploadItem{


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind feature


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #216 


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
A new flag `--dry-run` could be used to run `push` command without making any change on Google Photos. No files will be uploaded.

**Does this pull request add new dependencies?**  
No

**What else do we need to know?**  
The command still ask for credentials, this could be removed from code, because there is no need to connect to Google Photos, but it has been maintained to simplify the code.