### PR TITLE
Skip directories that are excluded.

### DIFF
--- a/upload/filter.go
+++ b/upload/filter.go
@@ -65,10 +65,12 @@ func NewFilter(includePatterns []string, excludePatterns []string, allowVideos b
 //   - item is not in the exclude pattern
 func (f *Filter) IsAllowed(fp string) bool {
 	// allow all included files that are not excluded
-	if f.isIncluded(fp) && !f.isExcluded(fp) {
-		return true
-	}
-	return false
+	return f.isIncluded(fp) && !f.isExcluded(fp)
+}
+
+// Useful for skipping directories that match an exclude
+func (f *Filter) IsExcluded(fp string) bool {
+	return f.isExcluded(fp)
 }
 
 func translatePatterns(pat []string) []string {


### PR DESCRIPTION
It's often possible to write exclude filters that cover directories as
well as files. If a directory is excluded, so are all the files in it,
so we can save some time by skipping walking that directory

**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  

It makes the runtime of a push much faster for my configuration (which has excludes for directories for years I have already uploaded)

**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  

Sort of - the log output of a push will change - it'll potentially be smaller, and it will print a new message when it skips a directory.

**Does this pull request add new dependencies?**  

No

**What else do we need to know?**  

I'm not a go programmer, so I've probably broken many of the secret rules of go. I have been running this amended version locally to good effect, so I think it does at least work. Let me know if you have any questions :-)