### PR TITLE
password from envvar

### DIFF
--- a/.docs/configuration.md
+++ b/.docs/configuration.md
@@ -37,7 +37,8 @@ Available options for secrets backend are:
 "keychain"          For OS X keychain support
 "kwallet"           For KDE Secrets Manager support
 "wincred"           For Windows credentials support
-"file"              For encrypted file support - needs interaction to supply a symetric encryption key
+"file"              For encrypted file support - the symetric encryption key is read from the environment variable 
+                    `KEYRING_ENCRYPTION_KEY` if it is set, otherwise it is read from the terminal (needs interaction).
 "pass"              For Password Store support - needs user interaction to supply a GPG pass key
 ```
 

--- a/datastore/tokenstore/repository_keyring.go
+++ b/datastore/tokenstore/repository_keyring.go
@@ -126,13 +126,18 @@ func (r *KeyringRepository) getToken(email string) (oauth2.Token, error) {
 	return tk, nil
 }
 
-
 func terminalPrompt(_ string) (string, error) {
-	fmt.Print("Enter the passphrase to open the token store: ")
-	b, err := terminal.ReadPassword(int(os.Stdin.Fd()))
-	if err != nil {
-		return "", err
+	pwd := os.Getenv("KEYRING_ENCRYPTION_KEY")
+
+	if pwd == "" {
+		fmt.Print("Enter the passphrase to open the token store: ")
+		b, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return "", err
+		}
+		fmt.Println()
+		pwd = string(b)
 	}
-	fmt.Println()
-	return string(b), nil
+
+	return pwd, nil
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
Various issues related to headless server, #102, #202, etc

**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
If the user sets the environment variable `KEYRING_ENCRYPTION_KEY` then the prompt to enter the token store password will be skipped and the value of the environment variable will be used as password.

**Does this pull request add new dependencies?**  
No

**What else do we need to know?**  
This is a very simple solution to the password for headless server issues (I see now that there is a different approach proposed in PR #209).

As for security, yes it is a password in plain text stored on the system. Use it responsibly; minimize the scope of the environment variable, make sure to use restrictive permissions and owner:group on any file containing the password.
