### PR TITLE
Add two tagged patterns _IMAGE_EXTENSIONS_ and _RAW_EXTENSIONS_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
+### Added
+- Two new tagged patterns has been added: `_IMAGE_EXTENSIONS_`, matching [supported image file types](https://support.google.com/googleone/answer/6193313), and `_RAW_EXTENSIONS_`, matching [supported RAW file types](https://support.google.com/googleone/answer/6193313). ([#249][i249]) 
 ### Changed
 - `includePatterns` and `excludePatterns` configuration options has changed. It's using a new format, please review de [configuration documentation](.docs/configuration.md).
+- By default, if `includePatterns` is empty, `_IMAGE_EXTENSIONS_` will be used. ([#249][i249])  
 ### Fixed
 - Symlinks are now supported when scanning a folder. ([#190][i190])
 > **Note:** This application does not terminate if there are any non-terminating loops in the file structure.
 - `includePatterns` works as expected, with a clearer (I hope so) format. ([#152][i152])  
 ### Removed
 - Deprecated `uploadVideos` configuration option. It was deprecated in [v0.4.0](https://github.com/gphotosuploader/gphotos-uploader-cli/releases/tag/v0.4.0).
-                                                    
+                                          
+[i249]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/249                                               
 [i190]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/190
 [i152]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/152
 

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -10,11 +10,11 @@ type Filter struct {
 	excludePatterns []string
 }
 
-// New returns an initialized Filter struct. If includePatterns is empty, _ALL_FILES_ tagged pattern is used instead.
+// New returns an initialized Filter struct. If includePatterns is empty, _IMAGE_EXTENSIONS_ tagged pattern is used instead.
 func New(includePatterns []string, excludePatterns []string) *Filter {
 	includePatterns = translatePatterns(includePatterns)
 	if len(includePatterns) == 0 {
-		includePatterns = patternDictionary["_ALL_FILES_"]
+		includePatterns = patternDictionary["_IMAGE_EXTENSIONS_"]
 	}
 
 	f := Filter{

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -29,17 +29,17 @@ func TestFilter_Validate(t *testing.T) {
 	}
 }
 
-func TestFilter_AllowAllFiles(t *testing.T) {
+func TestFilter_AllowDefaultFiles(t *testing.T) {
 	var testCases = []struct {
 		file string
 		out  bool
 	}{
-		{"testdata/SampleAudio.mp3", true},
+		{"testdata/SampleAudio.mp3", false},
 		{"testdata/SampleJPGImage.jpg", true},
 		{"testdata/SamplePNGImage.png", true},
-		{"testdata/SampleSVGImage.svg", true},
-		{"testdata/SampleText.txt", true},
-		{"testdata/SampleVideo.mp4", true},
+		{"testdata/SampleSVGImage.svg", false},
+		{"testdata/SampleText.txt", false},
+		{"testdata/SampleVideo.mp4", false},
 		{"testdata/ScreenShotJPG.jpg", true},
 		{"testdata/ScreenShotPNG.png", true},
 	}
@@ -63,6 +63,32 @@ func TestFilter_AllowAllFiles(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("ByUsingTaggedPattern", func(t *testing.T) {
+		f := filter.New([]string{"_IMAGE_EXTENSIONS_"}, []string{""})
+		for _, tc := range testCases {
+			got := f.IsAllowed(tc.file)
+			if tc.out != got {
+				t.Errorf("Filter result was not expected: file=%s, want %t, got %t", tc.file, tc.out, got)
+			}
+		}
+	})
+}
+
+func TestFilter_AllowAllFiles(t *testing.T) {
+	var testCases = []struct {
+		file string
+		out  bool
+	}{
+		{"testdata/SampleAudio.mp3", true},
+		{"testdata/SampleJPGImage.jpg", true},
+		{"testdata/SamplePNGImage.png", true},
+		{"testdata/SampleSVGImage.svg", true},
+		{"testdata/SampleText.txt", true},
+		{"testdata/SampleVideo.mp4", true},
+		{"testdata/ScreenShotJPG.jpg", true},
+		{"testdata/ScreenShotPNG.png", true},
+	}
 
 	t.Run("ByUsingWildCardPattern", func(t *testing.T) {
 		f := filter.New([]string{"**"}, []string{""})
@@ -216,7 +242,7 @@ func TestFilter_DisallowFilesStartingWithScreenShot(t *testing.T) {
 		{"testdata/ScreenShotPNG.png", false},
 	}
 
-	f := filter.New([]string{""}, []string{"**/ScreenShot*"})
+	f := filter.New([]string{"_ALL_FILES_"}, []string{"**/ScreenShot*"})
 	for _, tc := range testCases {
 		got := f.IsAllowed(tc.file)
 		if tc.out != got {

--- a/internal/filter/patterns.go
+++ b/internal/filter/patterns.go
@@ -6,6 +6,15 @@ var patternDictionary = map[string][]string{
 	// _ALL_FILES match with all file extensions
 	"_ALL_FILES_": {"**"},
 
+	// _IMAGE_EXTENSIONS_ match with the supported photos file type extensions
+	// Source: https://support.google.com/photos/answer/6193313
+	"_IMAGE_EXTENSIONS_": {"**/*.jpg", "**/*.JPG", "**/*.jpeg", "**/*.JPEG", "**/*.png", "**/*.PNG", "**/*.webp", "**/*.WEBP", "**/*.gif", "**/*.GIF"},
+
+	// _RAW_EXTENSIONS_ match with the RAW file type extensions
+	// Source: https://support.google.com/photos/answer/6193313
+	// Source: https://en.wikipedia.org/wiki/Raw_image_format#Raw_filename_extensions_and_respective_camera_manufacturers
+	"_RAW_EXTENSIONS_": {"**/*.arw", "**/*.srf", "**/*.sr2", "**/*.crw", "**/*.cr2", "**/*.cr3", "**/*.dng", "**/*.nef", "**/*.nrw", "**/*.orf", "**/*.raf", "**/*.raw", "**/*.rw2"},
+
 	// _ALL_VIDEO_FILES match with all video file extensions supported by Google Photos
 	// Source: https://support.google.com/photos/answer/6193313.
 	"_ALL_VIDEO_FILES_": {"**/*.mpg", "**/*.mod", "**/*.mmv", "**/*.tod", "**/*.wmv", "**/*.asf", "**/*.avi", "**/*.divx", "**/*.mov", "**/*.m4v", "**/*.3gp", "**/*.3g2", "**/*.mp4", "**/*.m2t", "**/*.m2ts", "**/*.mts", "**/*.mkv",},

--- a/internal/upload/walker_test.go
+++ b/internal/upload/walker_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWalker_GetAllFiles(t *testing.T) {
-	var includePatterns = []string{""}
+	var includePatterns = []string{"_ALL_FILES_"}
 	var excludePatterns = []string{""}
 
 	var want = map[string]bool{
@@ -75,7 +75,7 @@ func TestWalker_GetAllPNGFiles(t *testing.T) {
 }
 
 func TestWalker_GetAllFilesExcludeFolder1(t *testing.T) {
-	var includePatterns = []string{""}
+	var includePatterns = []string{"_ALL_FILES_"}
 	var excludePatterns = []string{"folder1"}
 
 	var want = map[string]bool{


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind feature

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #249 


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
Yes, It enables two tagged patterns `_IMAGE_EXTENSIONS_` and `_RAW_EXTENSIONS_`.
