### PR TITLE
Fixes issue 262

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 2.0.1
+### Changed
+- Bump `google-photos-api-client-go` from `v2.0.0` to `v2.0.1`.
+### Fixed
+- Media item creation was failing when Google Photos was reporting errors on media creation. ([#262][i262])
+
+[i262]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/262
+
 ## 2.0.0
 > This is a **major upgrade** and it has some **non-backwards compatible changes**:
 > - `includePatterns` and `excludePatterns` configuration options has changed.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
 	github.com/facebookgo/symwalk v0.0.0-20150726040526-42004b9f3222
 	github.com/facebookgo/testname v0.0.0-20150612200628-5443337c3a12 // indirect
-	github.com/gphotosuploader/google-photos-api-client-go/v2 v2.0.0
+	github.com/gphotosuploader/google-photos-api-client-go/v2 v2.1.2
 	github.com/gphotosuploader/googlemirror v0.5.0
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/mattn/go-colorable v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,11 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gphotosuploader/google-photos-api-client-go/v2 v2.0.0 h1:PVpPJY3qI5BM5qmpXvxh/LTaLWqF+ADhhRkXtQ3staM=
 github.com/gphotosuploader/google-photos-api-client-go/v2 v2.0.0/go.mod h1:n1wY5x2BPm9iQRNzluk4t1wse+WYg6QXnxs2ZwSUpNI=
+github.com/gphotosuploader/google-photos-api-client-go/v2 v2.1.2 h1:54EZJ0UvGcETW48eRNajngBmmaoxYIPrJFrmfoLyAZo=
+github.com/gphotosuploader/google-photos-api-client-go/v2 v2.1.2/go.mod h1:R03L88wB1c+j62OToxh/Rew2TvZPTjxs164nH5CVC1E=
 github.com/gphotosuploader/googlemirror v0.5.0 h1:9a9CCUnAFo3qHp7U/epmdTiOvAzXCkVq5AQLo8PWBns=
 github.com/gphotosuploader/googlemirror v0.5.0/go.mod h1:L6A+2KW6d/OwjZ5QH2fGXJXsOtR115tj9w+YxdyjfUI=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind bug


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #262 


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
No

**Does this pull request add new dependencies?**  
Bump version of gphotosuploader/google-photos-api-client-go.