### PR TITLE
Bring back file last modification time check

### DIFF
--- a/internal/datastore/filetracker/entity_test.go
+++ b/internal/datastore/filetracker/entity_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gphotosuploader/gphotos-uploader-cli/internal/datastore/filetracker"
+	"time"
 )
 
 func TestTrackedFile_Hash(t *testing.T) {
@@ -19,7 +20,49 @@ func TestTrackedFile_Hash(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := filetracker.NewTrackedFile(tc.input)
-			got := f.Hash()
+			got := f.Hash
+			if tc.want != got {
+				t.Errorf("want: %s, got: %s", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestTrackedFile_ModTime(t *testing.T) {
+	testCases := []struct {
+		name string
+		input string
+		want time.Time
+	}{
+		{"Should return zero time value", "123456789", time.Time{}},
+		{"Should return time value", "1631350013816466000|123456789", time.Unix(0, 1631350013816466000)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := filetracker.NewTrackedFile(tc.input)
+			got := f.ModTime
+			if tc.want != got {
+				t.Errorf("want: %s, got: %s", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestTrackedFile_String(t *testing.T) {
+	testCases := []struct {
+		name string
+		input string
+		want string
+	}{
+		{"Should return the hash", "123456789", "123456789"},
+		{"Should return mtime and hash", "1631350013816466000|123456789", "1631350013816466000|123456789"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := filetracker.NewTrackedFile(tc.input)
+			got := f.String()
 			if tc.want != got {
 				t.Errorf("want: %s, got: %s", tc.want, got)
 			}

--- a/internal/datastore/filetracker/filetracker.go
+++ b/internal/datastore/filetracker/filetracker.go
@@ -65,7 +65,7 @@ func (ft FileTracker) Exist(file string) bool {
 	}
 
 	// checks if the file is the same (equal value)
-	if item.Hash() == hash {
+	if item.Hash == hash {
 		return true
 	}
 

--- a/internal/datastore/filetracker/filetracker.go
+++ b/internal/datastore/filetracker/filetracker.go
@@ -2,6 +2,9 @@ package filetracker
 
 import (
 	"fmt"
+	"os"
+
+	"github.com/gphotosuploader/gphotos-uploader-cli/internal/log"
 )
 
 var (
@@ -16,6 +19,8 @@ type FileTracker struct {
 	// Hasher allows to change the way that hashes are calculated. Uses xxHash32Hasher{} by default.
 	// Useful for testing.
 	Hasher Hasher
+
+	logger log.Logger
 }
 
 // Hasher is a Hasher to get the value of the file.
@@ -37,16 +42,26 @@ func New(r Repository) *FileTracker {
 	return &FileTracker{
 		repo:   r,
 		Hasher: xxHash32Hasher{},
+		logger: log.GetInstance(),
 	}
 }
 
 // Put marks a file as already uploaded to prevent re-uploads.
 func (ft FileTracker) Put(file string) error {
+	fileInfo, err := os.Stat(file)
+	if err != nil {
+		return err
+	}
+
 	hash, err := ft.Hasher.Hash(file)
 	if err != nil {
 		return err
 	}
-	item := NewTrackedFile(hash)
+	item := TrackedFile{
+		ModTime: fileInfo.ModTime(),
+		Hash: hash,
+	}
+
 	return ft.repo.Put(file, item)
 }
 
@@ -59,6 +74,17 @@ func (ft FileTracker) Exist(file string) bool {
 		return false
 	}
 
+	fileInfo, err := os.Stat(file)
+	if err != nil {
+		ft.logger.Debugf("Error retrieving file info for '%s' (%s).", file, err)
+		return false
+	}
+
+	if item.ModTime.Equal(fileInfo.ModTime()) {
+		ft.logger.Debugf("File modification time has not changed for '%s'.", file)
+		return true
+	}
+
 	hash, err := ft.Hasher.Hash(file)
 	if err != nil {
 		return false
@@ -66,6 +92,7 @@ func (ft FileTracker) Exist(file string) bool {
 
 	// checks if the file is the same (equal value)
 	if item.Hash == hash {
+		ft.logger.Debugf("File hash has not changed for '%s'.", file)
 		return true
 	}
 

--- a/internal/datastore/filetracker/filetracker.go
+++ b/internal/datastore/filetracker/filetracker.go
@@ -93,6 +93,13 @@ func (ft FileTracker) Exist(file string) bool {
 	// checks if the file is the same (equal value)
 	if item.Hash == hash {
 		ft.logger.Debugf("File hash has not changed for '%s'.", file)
+
+		// updates file marker with mtime to speed up comparison on next run
+		item.ModTime = fileInfo.ModTime()
+		if err = ft.repo.Put(file, item); err != nil {
+			ft.logger.Debugf("Error updating marker for '%s' with modification time (%s).", file, err)
+		}
+
 		return true
 	}
 

--- a/internal/datastore/filetracker/leveldb_repository.go
+++ b/internal/datastore/filetracker/leveldb_repository.go
@@ -38,7 +38,7 @@ func (r LevelDBRepository) Get(key string) (TrackedFile, error) {
 
 // Put stores the item under key.
 func (r LevelDBRepository) Put(key string, item TrackedFile) error {
-	return r.DB.Put([]byte(key), []byte(item.value), nil)
+	return r.DB.Put([]byte(key), []byte(item.String()), nil)
 }
 
 // Delete removes the item specified by key.


### PR DESCRIPTION
My motivation for this PR can be read in #303. 

After merging these changes, we have brought back support for checking the last modification time of a file, before comparing file hashes. Hashing a file is a relatively expensive operation, especially when done over network.

I have searched through the repository's history and found that the program originally did store and check file modification times. I believe it still makes sense to do this. I could not find any documentation on why this was removed, so please excuse me when this proposal goes against any design decisions that were made in the past.

Personally I'm happy with the results of this change. On a network share with a source folder containing only 387 already uploaded photos (3GB in total) this improved the runtime from 72 seconds to 4 seconds.

I think we can improve the serialized form of the `TrackedFile` struct. For now I went for the original form `timestamp|hash` (timestamp as int, hash as string, delimited with '|').

Another thing that I would like feedback on is that the `Exists` function in `FileTracker` now possibly has the side effect of updating the `ModTime` field of the file marker. This is needed when the file last modified time changes, without changes to the file contents and when we don't have yet stored the last modified time on the marker (existing configurations).

It might be better to split that up to make the `Exists` function truly idempotent.

I will continue to do more tests with my own photo library, but this PR is ready for review.

**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #303 

**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
No

**Does this pull request add new dependencies?**  
No