### PR TITLE
Release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 3.2.0
+### Changed
+- Reduce the cost of tracking already uploaded files by bringing back file last modification time check ([#306][i306])
+
+[i306]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/306
+
 ## 3.1.1
 ### Fixed
 - Keychain backend not working on macOS. Thanks to [@mlangenberg](https://github.com/mlangenberg) ([#302][i302])

--- a/internal/datastore/filetracker/filetracker.go
+++ b/internal/datastore/filetracker/filetracker.go
@@ -66,7 +66,11 @@ func (ft FileTracker) Put(file string) error {
 }
 
 // Exist checks if the file was already uploaded.
-// Exist compares the value of the file against the repository.
+// Exist compares the last modification time of the file against the one in the repository.
+// Last time modification comparison tries to reduce the number of times where the hash comparison
+// is needed.
+// In case that last modification time has changed (or it doesn't exist - retro compatibility),
+// it compares a hash of the content of the file against the one in the repository.
 func (ft FileTracker) Exist(file string) bool {
 	// Get returns ErrItemNotFound if the repo does not contains the key.
 	item, err := ft.repo.Get(file)


### PR DESCRIPTION
### Changed
- Reduce the cost of tracking already uploaded files by bringing back file last modification time check ([#306][i306])

[i306]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/306