### PR TITLE
Improve go card

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.39
+          version: v1.42

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COVERAGE_FILE := $(TMP_DIR)/coverage.txt
 COVERAGE_HTML_FILE := $(TMP_DIR)/coverage.html
 GORELEASER := $(TMP_DIR)/goreleaser
 GOLANGCI := $(TMP_DIR)/golangci-lint
-GOLANGCI_VERSION := 1.39.0
+GOLANGCI_VERSION := 1.42.1
 
 # set how to open files based on OS and ARCH.
 UNAME_OS := $(shell uname -s)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -77,7 +77,7 @@ func Start(ctx context.Context, path string) (*App, error) {
 	return app, nil
 }
 
-// Start initializes the application without reading the configuration.
+// StartWithoutConfig initializes the application without reading the configuration.
 // The provided path is the expanded and absolute path to the application data folder.
 func StartWithoutConfig(fs afero.Fs, path string) (*App, error) {
 	app := &App{

--- a/internal/app/oauth_internals_test.go
+++ b/internal/app/oauth_internals_test.go
@@ -25,7 +25,7 @@ func TestAskForAuthCodeInTerminal(t *testing.T) {
 
 }
 
-func assertExpectedError(t *testing.T, errExpected bool, err error, ) {
+func assertExpectedError(t *testing.T, errExpected bool, err error) {
 	if errExpected && err == nil {
 		t.Fatalf("error was expected, but not produced")
 	}

--- a/internal/app/oauth_test.go
+++ b/internal/app/oauth_test.go
@@ -166,7 +166,7 @@ func (m mockedTokenManager) Close() error {
 	return m.CloseFn()
 }
 
-func assertExpectedError(t *testing.T, errExpected bool, err error, ) {
+func assertExpectedError(t *testing.T, errExpected bool, err error) {
 	if errExpected && err == nil {
 		t.Fatalf("error was expected, but not produced")
 	}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gphotosuploader/gphotos-uploader-cli/internal/cmd/flags"
 )
 
-// InitCmd holds the required data for the init cmd
+// AuthCmd holds the required data for the init cmd
 type AuthCmd struct {
 	*flags.GlobalFlags
 }

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -2,7 +2,7 @@ package cmd_test
 
 import "testing"
 
-func assertExpectedError(t *testing.T, errExpected bool, err error, ) {
+func assertExpectedError(t *testing.T, errExpected bool, err error) {
 	if errExpected && err == nil {
 		t.Fatalf("error was expected, but not produced")
 	}

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -29,7 +29,7 @@ func NewVersionCmd() *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Prints current version",
-		Run:  cmd.Run,
+		Run:   cmd.Run,
 	}
 
 	return versionCmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,18 +48,18 @@ func Exists(fs afero.Fs, filename string) bool {
 // SafePrint returns the configuration, removing sensible fields.
 func (c Config) SafePrint() string {
 	printableConfig := struct {
-		APIAppCredentials APIAppCredentials
-		Account string
+		APIAppCredentials  APIAppCredentials
+		Account            string
 		SecretsBackendType string
-		Jobs []FolderUploadJob
+		Jobs               []FolderUploadJob
 	}{
 		APIAppCredentials: APIAppCredentials{
 			ClientID:     c.APIAppCredentials.ClientID,
 			ClientSecret: "REMOVED",
 		},
-		Account: c.Account,
+		Account:            c.Account,
 		SecretsBackendType: c.SecretsBackendType,
-		Jobs: c.Jobs,
+		Jobs:               c.Jobs,
 	}
 	b, _ := json.Marshal(printableConfig)
 	return fmt.Sprint(string(b))
@@ -217,8 +217,8 @@ func defaultSettings() Config {
 		Account: "YOUR_GOOGLE_PHOTOS_ACCOUNT",
 		Jobs: []FolderUploadJob{
 			{
-				SourceFolder: "YOUR_FOLDER_PATH",
-				CreateAlbums: "folderName",
+				SourceFolder:      "YOUR_FOLDER_PATH",
+				CreateAlbums:      "folderName",
 				DeleteAfterUpload: false,
 			},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -99,8 +99,8 @@ func TestConfig_SafePrint(t *testing.T) {
 		SecretsBackendType: "auto",
 		Jobs: []config.FolderUploadJob{
 			{
-				SourceFolder: "foo",
-				CreateAlbums: "folderPath",
+				SourceFolder:      "foo",
+				CreateAlbums:      "folderPath",
 				DeleteAfterUpload: false,
 				IncludePatterns:   []string{},
 				ExcludePatterns:   []string{},

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -39,7 +39,8 @@ type FolderUploadJob struct {
 	// folderName: Creates album with the name based on the folder name.
 	CreateAlbums string `json:"CreateAlbums,omitempty"`
 
-	// DEPRECATED: MakeAlbums is deprecated, use Config.Jobs.CreateAlbums instead.
+	// MakeAlbums is deprecated, use Config.Jobs.CreateAlbums instead.
+	// DEPRECATED
 	MakeAlbums MakeAlbums `json:"-"`
 
 	// DeleteAfterUpload if it is true, the app will remove files after upload them.
@@ -52,11 +53,14 @@ type FolderUploadJob struct {
 	ExcludePatterns []string `json:"ExcludePatterns"`
 }
 
-// DEPRECATED: MakeAlbums is deprecated, use Config.Jobs.CreateAlbums instead
+// MakeAlbums is deprecated, use Config.Jobs.CreateAlbums instead
+// DEPRECATED
 type MakeAlbums struct {
-	// DEPRECATED: Enabled is deprecated, use Config.Jobs.CreateAlbums instead.
+	// Enabled is deprecated, use Config.Jobs.CreateAlbums instead.
+	// DEPRECATED
 	Enabled bool `json:"-"`
 
-	// DEPRECATED: Use is deprecated, use Config.Jobs.CreateAlbums instead.
+	// Use is deprecated, use Config.Jobs.CreateAlbums instead.
+	// DEPRECATED
 	Use string `json:"-"`
 }

--- a/internal/datastore/filetracker/entity.go
+++ b/internal/datastore/filetracker/entity.go
@@ -1,15 +1,15 @@
 package filetracker
 
 import (
+	"strconv"
 	"strings"
 	"time"
-	"strconv"
 )
 
 // TrackedFile represents a tracked file in the repository.
 type TrackedFile struct {
 	ModTime time.Time
-	Hash string
+	Hash    string
 }
 
 // NewTrackedFile returns a TrackedFile with the specified values
@@ -30,7 +30,7 @@ func NewTrackedFile(value string) TrackedFile {
 	}
 
 	return TrackedFile{
-		Hash: hash,
+		Hash:    hash,
 		ModTime: modTime,
 	}
 }

--- a/internal/datastore/filetracker/entity_test.go
+++ b/internal/datastore/filetracker/entity_test.go
@@ -2,9 +2,9 @@ package filetracker_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gphotosuploader/gphotos-uploader-cli/internal/datastore/filetracker"
-	"time"
 )
 
 func TestTrackedFile_Hash(t *testing.T) {
@@ -30,9 +30,9 @@ func TestTrackedFile_Hash(t *testing.T) {
 
 func TestTrackedFile_ModTime(t *testing.T) {
 	testCases := []struct {
-		name string
+		name  string
 		input string
-		want time.Time
+		want  time.Time
 	}{
 		{"Should return zero time value", "123456789", time.Time{}},
 		{"Should return time value", "1631350013816466000|123456789", time.Unix(0, 1631350013816466000)},
@@ -51,9 +51,9 @@ func TestTrackedFile_ModTime(t *testing.T) {
 
 func TestTrackedFile_String(t *testing.T) {
 	testCases := []struct {
-		name string
+		name  string
 		input string
-		want string
+		want  string
 	}{
 		{"Should return the hash", "123456789", "123456789"},
 		{"Should return mtime and hash", "1631350013816466000|123456789", "1631350013816466000|123456789"},

--- a/internal/datastore/filetracker/filetracker.go
+++ b/internal/datastore/filetracker/filetracker.go
@@ -59,7 +59,7 @@ func (ft FileTracker) Put(file string) error {
 	}
 	item := TrackedFile{
 		ModTime: fileInfo.ModTime(),
-		Hash: hash,
+		Hash:    hash,
 	}
 
 	return ft.repo.Put(file, item)

--- a/internal/datastore/tokenmanager/keyring_repository.go
+++ b/internal/datastore/tokenmanager/keyring_repository.go
@@ -7,8 +7,8 @@ import (
 	"syscall"
 
 	"github.com/99designs/keyring"
-	"golang.org/x/term"
 	"golang.org/x/oauth2"
+	"golang.org/x/term"
 )
 
 // KeyringRepository represents a repository provided by different secrets

--- a/internal/upload/walker_test.go
+++ b/internal/upload/walker_test.go
@@ -148,10 +148,10 @@ func getScanFolderResult(includePatterns []string, excludePatterns []string) (ma
 	filterFiles := filter.MustCompile(includePatterns, excludePatterns)
 
 	u := upload.UploadFolderJob{
-		FileTracker:        ft,
-		SourceFolder:       "testdata",
-		CreateAlbums:       "Off",
-		Filter:             filterFiles,
+		FileTracker:  ft,
+		SourceFolder: "testdata",
+		CreateAlbums: "Off",
+		Filter:       filterFiles,
 	}
 
 	foundItems, err := u.ScanFolder(&mock.Logger{})

--- a/internal/worker/queue.go
+++ b/internal/worker/queue.go
@@ -68,6 +68,7 @@ func NewJobQueue(maxWorkers int, logger log.Logger) *JobQueue {
 	}
 }
 
+// ChanJobResults returns the channel where the Job give the results
 func (q *JobQueue) ChanJobResults() chan JobResult {
 	return q.jobResults
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
Improve go-card warnings

```
gofmt84%

Gofmt formats Go programs. We run gofmt -s on your code, where -s is for the "simplify" command

        gphotos-uploader-cli/internal/config/config.go
        Line 1: warning: file is not gofmted with -s (gofmt)

        gphotos-uploader-cli/internal/config/config_test.go
        Line 1: warning: file is not gofmted with -s (gofmt)

        gphotos-uploader-cli/internal/datastore/tokenmanager/keyring_repository.go
        Line 1: warning: file is not gofmted with -s (gofmt)

        gphotos-uploader-cli/internal/cmd/helpers_test.go
        Line 1: warning: file is not gofmted with -s (gofmt)

        gphotos-uploader-cli/internal/cmd/version.go
        Line 1: warning: file is not gofmted with -s (gofmt)

        gphotos-uploader-cli/internal/upload/walker_test.go
        Line 1: warning: file is not gofmted with -s (gofmt)

        gphotos-uploader-cli/internal/app/oauth_internals_test.go
        Line 1: warning: file is not gofmted with -s (gofmt)

        gphotos-uploader-cli/internal/app/oauth_test.go
        Line 1: warning: file is not gofmted with -s (gofmt)
```

```
golint75%

Golint is a linter for Go source code.

        gphotos-uploader-cli/internal/config/schema.go
        Line 55: warning: comment on exported type MakeAlbums should be of the form "MakeAlbums ..." (with optional leading article) (golint)

        gphotos-uploader-cli/internal/worker/queue.go
        Line 71: warning: exported method JobQueue.ChanJobResults should have comment or be unexported (golint)


        gphotos-uploader-cli/internal/cmd/auth.go
        Line 12: warning: comment on exported type AuthCmd should be of the form "AuthCmd ..." (with optional leading article) (golint)

        gphotos-uploader-cli/internal/app/app.go
        Line 80: warning: comment on exported function StartWithoutConfig should be of the form "StartWithoutConfig ..." (golint)

```