### PR TITLE
Refactor auth command to authenticate users

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -49,6 +49,22 @@ type App struct {
 // Start initializes the application with the services defined by a given configuration.
 // The provided path is the expanded and absolute path to the application data folder.
 func Start(ctx context.Context, path string) (*App, error) {
+	app, err := StartServices(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	app.Client, err = app.AuthenticateFromToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return app, nil
+}
+
+// StartServices initializes the services defined by a given configuration.
+// The provided path is the expanded and absolute path to the application data folder.
+func StartServices(ctx context.Context, path string) (*App, error) {
 	var err error
 
 	app := &App{
@@ -66,11 +82,6 @@ func Start(ctx context.Context, path string) (*App, error) {
 	app.Logger.Debugf("Current configuration: %s", app.Config.SafePrint())
 
 	if err := app.startServices(); err != nil {
-		return nil, err
-	}
-
-	app.Client, err = app.NewOAuth2Client(ctx)
-	if err != nil {
 		return nil, err
 	}
 

--- a/internal/app/oauth.go
+++ b/internal/app/oauth.go
@@ -2,20 +2,21 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/gphotosuploader/gphotos-uploader-cli/internal/oauth"
 )
 
-// NewOAuth2Client returns a HTTP client authenticated in Google Photos.
-// NewOAuth2Client will get (from Token Manager) or create the token.
-func (app App) NewOAuth2Client(ctx context.Context) (*http.Client, error) {
+// AuthenticateFromToken returns an HTTP client authenticated in Google Photos.
+// AuthenticateFromToken will use the token from the Token Manage.
+func (app App) AuthenticateFromToken(ctx context.Context) (*http.Client, error) {
 	account := app.Config.Account
-	app.Logger.Infof("Getting OAuth token for '%s'", account)
+	app.Logger.Infof("Authenticating using token for '%s'", account)
 
 	token, err := app.TokenManager.Get(account)
 	if err != nil {
-		app.Logger.Debugf("Unable to retrieve token from token manager: %s", err)
+		return nil, fmt.Errorf("unable to retrieve token, have you authenticated before?: %w", err)
 	}
 
 	cfg := &oauth.Config{
@@ -24,12 +25,38 @@ func (app App) NewOAuth2Client(ctx context.Context) (*http.Client, error) {
 		Logf:         app.Logger.Debugf,
 	}
 
-	token, err = oauth.GetToken(ctx, cfg, token)
+	token, err = oauth.RefreshToken(ctx, cfg, token)
 	if err != nil {
 		return nil, err
 	}
 
 	app.Logger.Donef("Token is valid, expires at %s", token.Expiry)
+
+	if err := app.TokenManager.Put(account, token); err != nil {
+		app.Logger.Debugf("Failed to store token into token manager: %s", err)
+	}
+
+	return oauth.Client(ctx, cfg, token)
+}
+
+// AuthenticateFromWeb returns an HTTP client authenticated in Google Photos.
+// AuthenticateFromWeb will create a new token after completing the OAuth 2.0 flow.
+func (app *App) AuthenticateFromWeb(ctx context.Context) (*http.Client, error) {
+	account := app.Config.Account
+	app.Logger.Infof("Getting authentication token for '%s'", account)
+
+	cfg := &oauth.Config{
+		ClientID:     app.Config.APIAppCredentials.ClientID,
+		ClientSecret: app.Config.APIAppCredentials.ClientSecret,
+		Logf:         app.Logger.Debugf,
+	}
+
+	token, err := oauth.GetToken(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	app.Logger.Donef("Token obtained, expires at %s", token.Expiry)
 
 	if err := app.TokenManager.Put(account, token); err != nil {
 		app.Logger.Debugf("Failed to store token into token manager: %s", err)

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -19,8 +19,8 @@ func NewAuthCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 
 	authCmd := &cobra.Command{
 		Use:   "auth",
-		Short: "Authenticate with Google Photos to refresh tokens",
-		Long:  `Force authentication against Google Photos to refresh tokens.`,
+		Short: "Authenticate account with Google Photos to get OAuth 2.0 token",
+		Long:  `Force authentication against Google Photos to get OAuth 2.0 token.`,
 		Args:  cobra.NoArgs,
 		RunE:  cmd.Run,
 	}
@@ -30,7 +30,7 @@ func NewAuthCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 
 func (cmd *AuthCmd) Run(cobraCmd *cobra.Command, args []string) error {
 	ctx := context.Background()
-	cli, err := app.Start(ctx, cmd.CfgDir)
+	cli, err := app.StartServices(ctx, cmd.CfgDir)
 	if err != nil {
 		return err
 	}
@@ -38,6 +38,10 @@ func (cmd *AuthCmd) Run(cobraCmd *cobra.Command, args []string) error {
 		_ = cli.Stop()
 	}()
 
-	cli.Logger.Donef("Successful authentication for account '%s'", cli.Config.Account)
-	return nil
+	_, err = cli.AuthenticateFromWeb(ctx)
+	if err == nil {
+		cli.Logger.Donef("Successful authentication for account '%s'", cli.Config.Account)
+	}
+
+	return err
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
related to #326 


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
`gphotos-uploader-cli` will be used to authenticate users and get the OAuth 2.0 token, while the rest of commands will use the OAuth 2.0 token.
