### PR TITLE
Ammend a previous command renaming. Command is gphotos-uploader-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 # Binary releases
 /dist/
-/gphotos-cli
+/gphotos-uploader-cli
 
 # Used for temporary files such as coverage files.
 /.tmp/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TEST_LDFLAGS=-ldflags "-X ${CONFIGURATION_PACKAGE}.versionString=$(TEST_VERSION)
 # go source files, ignore vendor directory
 PKGS = $(shell go list ./... | grep -v /vendor)
 SRC := main.go
-BINARY := gphotos-cli
+BINARY := gphotos-uploader-cli
 
 # Temporary files to be used, you can changed it calling `make TMP_DIR=/tmp`
 TMP_DIR ?= .tmp

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -21,13 +21,13 @@ Google Photos Command Line Interface (CLI)
 This CLI application allows you to upload pictures and videos to Google Photos. You can upload folders to your Google Photos account and organize them in albums automatically. Additionally, you can list albums and media items already uploaded to Google Photos.
 
 To get started, initialize your settings by running the following command:
-$ gphotos-cli init
+$ gphotos-uploader-cli init
 
 Once configured, you can uploading your files with this command:
-$ gphotos-cli push
+$ gphotos-uploder-cli push
 
 Or you can list your albums in Google Photos by running:
-$ gphotos-cli list albums
+$ gphotos-uploader-cli list albums
 
 For more information, visit: https://gphotosuploader.github.io/gphotos-uploader-cli.
 `
@@ -42,7 +42,7 @@ For more information, visit: https://gphotosuploader.github.io/gphotos-uploader-
 func NewCommand() *cobra.Command {
 	// ArduinoCli is the root command
 	gphotosCLI := &cobra.Command{
-		Use:               "gphotos-cli",
+		Use:               "gphotos-uploader-cli",
 		Short:             "Google Photos CLI.",
 		Long:              longCommandDescription,
 		PersistentPreRunE: preRun,

--- a/internal/cli/flags/flags.go
+++ b/internal/cli/flags/flags.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	// defaultApplicationDataFolder is the default folder where to store application data.
-	defaultApplicationDataFolder = "~/.gphotos-cli"
+	defaultApplicationDataFolder = "~/.gphotos-uploader-cli"
 )
 
 // GlobalFlags is the flags that contain the global flags

--- a/internal/datastore/tokenmanager/keyring_repository_test.go
+++ b/internal/datastore/tokenmanager/keyring_repository_test.go
@@ -137,5 +137,5 @@ func getDefaultToken() *oauth2.Token {
 }
 
 func tempDir() string {
-	return filepath.Join(os.TempDir(), fmt.Sprintf("gphotos-cli.%d", time.Now().UnixNano()))
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gphotos-uploader-cli.%d", time.Now().UnixNano()))
 }

--- a/version/version.go
+++ b/version/version.go
@@ -28,7 +28,7 @@ type Info struct {
 
 func NewInfo() *Info {
 	return &Info{
-		Application:   "gphotos-cli",
+		Application:   "gphotos-uploader-cli",
 		VersionString: versionString,
 	}
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -12,11 +12,11 @@ import (
 //	  -X github.com/gphotosuploader/gphotos-uploader-cli/version.versionString=0.0.0-test.preview'
 func TestBuildInjectedInfo(t *testing.T) {
 	goldenInfo := Info{
-		Application:   "gphotos-cli",
+		Application:   "gphotos-uploader-cli",
 		VersionString: "0.0.0-test.preview",
 	}
 	info := NewInfo()
 	require.Equal(t, goldenInfo.Application, info.Application)
 	require.Equal(t, goldenInfo.VersionString, info.VersionString)
-	require.Equal(t, "gphotos-cli Version: 0.0.0-test.preview", info.String())
+	require.Equal(t, "gphotos-uploader-cli Version: 0.0.0-test.preview", info.String())
 }


### PR DESCRIPTION
Signed-off-by: pacoorozco <paco@pacoorozco.info>

**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
In a previous PR we renamed the CLI to `gphotos-cli`, but this is causing confusion between the repository name and the CLI.

In this PR, we rename it again to `gphotos-uploader-cli`. 

**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
Yes, it will change the name of the command: `gphotos-uploader-cli`. The old name was not released and the documentation was still using to `gphotos-uploader-cli`


**Does this pull request add new dependencies?**  


**What else do we need to know?**  
