### PR TITLE
Add a flag to the auth command to set the local port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 4.1.0
+### Added
+- Flag `--port` to configure the port where the authentication server will listen to when using the `auth` command ([#370][i370])
+
+[i370]: https://github.com/gphotosuploader/gphotos-uploader-cli/issues/370
+
 ## 4.0.0
 ### Added
 - Support for the latest published Go version (1.21). This project will maintain compatibility with the latest **two major versions** published.

--- a/internal/app/oauth.go
+++ b/internal/app/oauth.go
@@ -41,7 +41,7 @@ func (app *App) AuthenticateFromToken(ctx context.Context) (*http.Client, error)
 
 // AuthenticateFromWeb returns an HTTP client authenticated in Google Photos.
 // AuthenticateFromWeb will create a new token after completing the OAuth 2.0 flow.
-func (app *App) AuthenticateFromWeb(ctx context.Context) (*http.Client, error) {
+func (app *App) AuthenticateFromWeb(ctx context.Context, port int) (*http.Client, error) {
 	account := app.Config.Account
 	app.Logger.Infof("Getting authentication token for '%s'", account)
 
@@ -49,6 +49,7 @@ func (app *App) AuthenticateFromWeb(ctx context.Context) (*http.Client, error) {
 		ClientID:     app.Config.APIAppCredentials.ClientID,
 		ClientSecret: app.Config.APIAppCredentials.ClientSecret,
 		Logf:         app.Logger.Debugf,
+		Port:         port,
 	}
 
 	token, err := oauth.GetToken(ctx, cfg)

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -12,6 +12,9 @@ import (
 // AuthCmd holds the required data for the init cmd
 type AuthCmd struct {
 	*flags.GlobalFlags
+
+	// command flags
+	Port int
 }
 
 func NewCommand(globalFlags *flags.GlobalFlags) *cobra.Command {
@@ -24,6 +27,8 @@ func NewCommand(globalFlags *flags.GlobalFlags) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE:  cmd.Run,
 	}
+
+	authCmd.Flags().IntVarP(&cmd.Port, "port", "p", 0, "port on which the auth server will listen (default 0)")
 
 	return authCmd
 }
@@ -38,7 +43,7 @@ func (cmd *AuthCmd) Run(cobraCmd *cobra.Command, args []string) error {
 		_ = cli.Stop()
 	}()
 
-	_, err = cli.AuthenticateFromWeb(ctx)
+	_, err = cli.AuthenticateFromWeb(ctx, cmd.Port)
 	if err == nil {
 		cli.Logger.Donef("Successful authentication for account '%s'", cli.Config.Account)
 	}


### PR DESCRIPTION
Signed-off-by: pacoorozco <paco@pacoorozco.info>

**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #370


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
Yes, a new flag available in the `auth` command to set the local port to bind the authentication server.

**Does this pull request add new dependencies?**  
No


**What else do we need to know?**  
