### PR TITLE
Introducing the option to bind the HTTP server to addresses other than local

### DIFF
--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -16,6 +16,7 @@ type AuthCmd struct {
 
 	// command flags
 	Port                int
+	LocalBindAddress    string
 	RedirectURLHostname string
 }
 
@@ -31,7 +32,8 @@ func NewCommand(globalFlags *flags.GlobalFlags) *cobra.Command {
 	}
 
 	authCmd.Flags().IntVar(&cmd.Port, "port", 0, "port on which the auth server will listen (default 0)")
-	authCmd.Flags().StringVar(&cmd.RedirectURLHostname, "redirect-url-hostname", "", "hostname of the redirect URL (default localhost)")
+	authCmd.Flags().StringVar(&cmd.LocalBindAddress, "local-bind-address", "127.0.0.1", "local address on which the auth server will listen")
+	authCmd.Flags().StringVar(&cmd.RedirectURLHostname, "redirect-url-hostname", "localhost", "hostname of the redirect URL")
 
 	return authCmd
 }
@@ -48,9 +50,8 @@ func (cmd *AuthCmd) Run(cobraCmd *cobra.Command, args []string) error {
 
 	// customize authentication options based on the command line parameters
 	authOptions := app.AuthenticationOptions{}
-	if cmd.Port != 0 {
-		authOptions.LocalServerBindAddress = fmt.Sprintf("127.0.0.1:%d", cmd.Port)
-	}
+	authOptions.LocalServerBindAddress = fmt.Sprintf("%s:%d", cmd.LocalBindAddress, cmd.Port)
+
 	if cmd.RedirectURLHostname != "" {
 		authOptions.RedirectURLHostname = cmd.RedirectURLHostname
 	}

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -110,7 +110,7 @@ func (c *Config) getTokenFromWeb(ctx context.Context) (*oauth2.Token, error) {
 		select {
 		case url := <-ready:
 			fmt.Printf("\nVisit the URL below in a browser:\n\n%s\n\n", url)
-			fmt.Printf("If you are opening the url manually on a different machine you will need to curl the result URL on this machine manually.\n\n")
+			fmt.Printf("If you need to open the URL from another machine, you should use the --local-bind-address and --redirect-url-hostname flags.\n\n")
 			return nil
 		case <-ctx.Done():
 			return fmt.Errorf("context done while waiting for authorization: %w", ctx.Err())


### PR DESCRIPTION
…n local ones.

**What issue type does this pull request address?** (keep at least one, remove the others)  

/kind feature


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #
n/a

**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  

Yes, it adds the ability to bind the authentication server to an IP other than the local host.

I use this tool on my Synology storage device, and the recommended authentication method with curl was really time-consuming and hard to understand without knowledge about OAuth. I hope this simplifies it a bit more.

I assume this is a pretty common use case, but I may be wrong. If you feel this is not the case, feel free to reject it.

**Does this pull request add new dependencies?**  

No

**What else do we need to know?**  

Here's the corrected sentence:

I unified how defaults are handled for the auth use case and took advantage of build in default handling.